### PR TITLE
Update test setup to make it more reliable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "rollup.config.flow": "1.1.0",
     "selenium-webdriver": "4.0.0-alpha.1",
     "source-map-support": "0.5.6",
-    "tail": "1.2.4",
     "tap-finished": "0.0.1",
     "web-ext": "2.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7521,10 +7521,6 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-tail@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/tail/-/tail-1.2.4.tgz#0877f3123258fd6e65320c0b27097a1343c2add1"
-
 tap-finished@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tap-finished/-/tap-finished-0.0.1.tgz#08b5b543fdc04830290c6c561279552e71c4bd67"


### PR DESCRIPTION
Previous version had to use a workaround to obtain `stdout` from the Firefox (reasons described in https://github.com/mozilla/libdweb/issues/12#issuecomment-407929035) by forwarding it to a temporary file which was then watched for changes and read to analyze output.

That solution was very unreliable. This change instead uses node [`cluster`](https://nodejs.org/dist/latest-v10.x/docs/api/cluster.html) api and runs selenium in the worker process while analyzing all of the `stdout` from the master, this removes unreliable workaround described above.

This also sets a foundation for the future work were master will be able to traverse test directory and dispatch test paths to the worker to run.