### PR TITLE
Allow asyn protocol handlers

### DIFF
--- a/demo/protocol/protocol.js
+++ b/demo/protocol/protocol.js
@@ -14,6 +14,20 @@ browser.protocol.registerProtocol("dweb", request => {
         })()
       }
     }
+    case "dweb://async/": {
+      return new Promise((resolve, reject) => {
+        setTimeout(resolve, 100, {
+          contentType: "text/plain",
+          content: (async function*() {
+            const encoder = new TextEncoder("utf-8")
+            yield encoder.encode("Async response yo!").buffer
+          })()
+        })
+      })
+    }
+    case "dweb://crash/": {
+      throw Error("Boom!")
+    }
     case "dweb://text/": {
       return {
         content: (async function*() {

--- a/src/protocol/protocol.json
+++ b/src/protocol/protocol.json
@@ -37,7 +37,7 @@
         "id": "ProtocolHandler",
         "type": "function",
         "description": "Protocol handler",
-        "async": false,
+        "async": true,
         "parameters": [
           {
             "name": "request",

--- a/src/protocol/router.js
+++ b/src/protocol/router.js
@@ -414,8 +414,9 @@ class Channel /*::implements nsIChannel, nsIRequest*/ {
     this.byteOffset += byteLength
   }
 
-  end(_) {
+  end({ status }) {
     this.readyState = CLOSED
+    this.status = status
     this.contentLength = this.byteOffset
     debug && console.log(`end${pid} ${JSON.stringify(this)}`)
     this.close()
@@ -624,6 +625,7 @@ export type Body = {
 
 export type End = {
   type: "end",
+  status:nsresult,
   requestID: string
 }
 


### PR DESCRIPTION
This allows protocol implementers to sniff content for contentType detection without blocking.

fix #56