### PR TITLE
[WIP] Add links to default dweb page in protocol example

### DIFF
--- a/demo/protocol/protocol.js
+++ b/demo/protocol/protocol.js
@@ -1,4 +1,5 @@
 browser.protocol.registerProtocol("dweb", request => {
+  examples = ["stream", "async", "crash", "text", "html"]
   switch (request.url) {
     case "dweb://stream/": {
       return {
@@ -52,7 +53,10 @@ browser.protocol.registerProtocol("dweb", request => {
           const encoder = new TextEncoder("utf-8")
           yield encoder.encode("<h1>Hi there!</h1>\n").buffer
           yield encoder.encode(
-            `<p>You've succesfully loaded <strong>${request.url}</strong><p>`
+            `<p>You've succesfully loaded <strong>${request.url}</strong><p>
+            ${examples
+              .map(ex => `<a href=\"dweb://${ex}/\" >${ex}</a>`)
+              .join("<br>")}`
           ).buffer
         })()
       }


### PR DESCRIPTION
Currently dweb links don't have an effect.  I'm sure this would work by registering an on click function for each link, but I thought it would just work with `<a href="dweb://async">async</a>` since it works with other protocols.

Also do we have to use the `//`?  Is it not possible to just have `dweb:address` or `dweb:protocol:address`?