### PR TITLE
Fixes for browser.FileSystem createDirectory and removeDirectory

### DIFF
--- a/src/FileSystem/FileSystem.json
+++ b/src/FileSystem/FileSystem.json
@@ -475,6 +475,32 @@
             "optional": true
           }
         }
+      },
+      {
+        "id": "CreateDirOptions",
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "optional": true
+          },
+          "ignoreExisting": {
+            "type": "boolean",
+            "optional": true
+          },
+          "unixMode": {
+            "description":
+              "(ignored under non-Unix platforms) If specified, file creation mode, as per libc function open. If unspecified, files are created with a default mode of 0600 (file is private to the user, the user can read and write).",
+            "type": "number",
+            "optional": true
+          },
+          "winSecurity": {
+            "description":
+              "(ignored under non-Windows platforms) If specified, a security policy, as per Windows function CreateFile. If unspecified, no security attributes",
+            "type": "number",
+            "optional": true
+          }
+        }
       }
     ],
     "properties": {},

--- a/src/FileSystem/FileSystem.json
+++ b/src/FileSystem/FileSystem.json
@@ -501,6 +501,24 @@
             "optional": true
           }
         }
+      },
+      {
+        "id": "RemoveDirOptions",
+        "type": "object",
+        "properties": {
+          "ignoreAbsent": {
+            "type": "boolean",
+            "optional": true
+          },
+          "recursive": {
+            "type": "boolean",
+            "optional": true
+          },
+          "ignorePermissions": {
+            "type": "boolean",
+            "optional": true
+          }
+        }
       }
     ],
     "properties": {},

--- a/src/FileSystem/host.js
+++ b/src/FileSystem/host.js
@@ -657,7 +657,7 @@ class HostFileSystem /*::implements FileSystemManager*/ {
   ) /*: Promise<void>*/ {
     try {
       const file = await this.resolve(url)
-      return await OS.File.makeDir(file, options)
+      return await OS.File.makeDir(file, options || undefined)
     } catch (error) {
       return IOError.throw(error)
     }


### PR DESCRIPTION
This PR fixes a couple of issues with the `browser.FileSystem` API:
 * Add `CreateDirOptions` definition to the API schema. This was missing, so `createDirectory` would throw an error when it was called.
 * When calling `createDirectory` without the `options` argument, `null` was passed to the underlying `makeDir` call. This would then throw `Error: options is null`. Setting `options` to `undefined` if it is falsy fixes this.
 * Add `RemoveDirOptions` defintion to the API schema which was missing for `removeDirectory`

I'm not sure how to add testing for these, due to requiring user prompt for `mount`, but if you have suggestions I can add them to the PR.