### PR TITLE
Implement TCP and UDP sockets in parent process

### DIFF
--- a/demo/dgram/manifest.json
+++ b/demo/dgram/manifest.json
@@ -8,6 +8,11 @@
   "experiment_apis": {
     "UDPSocket": {
       "schema": "../../src/toolkit/components/extensions/schemas/udp.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["UDPSocket"]],
+        "script": "../../src/toolkit/components/extensions/parent/ext-udp.js"
+      },
       "child": {
         "scopes": ["addon_child"],
         "paths": [["UDPSocket"]],

--- a/demo/tcp/manifest.json
+++ b/demo/tcp/manifest.json
@@ -4,14 +4,21 @@
   "name": "tcp@libdweb",
   "description": "Extension containing libdweb TCPSocket API",
   "permissions": [],
-
+  "background": {
+    "scripts": ["test.js"]
+  },
   "experiment_apis": {
     "TCPSocket": {
-      "schema": "../../src/toolkit/components/extensions/tcp.json",
+      "schema": "../../src/toolkit/components/extensions/schemas/tcp.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["TCPSocket"]],
+        "script": "../../src/toolkit/components/extensions/parent/ext-tcp.js"
+      },
       "child": {
         "scopes": ["addon_child"],
         "paths": [["TCPSocket"]],
-        "script": "../../src/toolkit/components/extensions/ext-tcp.js"
+        "script": "../../src/toolkit/components/extensions/child/ext-tcp.js"
       }
     }
   },

--- a/src/toolkit/components/extensions/child/ext-tcp.js
+++ b/src/toolkit/components/extensions/child/ext-tcp.js
@@ -1,1073 +1,331 @@
-// @flow strict
+const { ExtensionError } = ExtensionUtils
 
-/*::
-import { Components, Cu, Cr, Ci, Cc, ExtensionAPI } from "gecko"
-import type {
-  BaseContext,
-  nsresult,
-  nsISupports,
-  nsISocketTransport,
-  nsIServerSocket,
-  TCPReadyState,
-  nsIInputStream,
-  nsIOutputStream,
-  nsIBinaryOutputStream,
-  nsIBinaryInputStream,
-  nsIAsyncInputStream,
-  nsIInputStreamPump,
-  nsIRequestObserver,
-  nsIEventTarget,
-
-  TCPServerSocketAPI,
-  TCPSocketAPI,
-  SocketOptions,
-  TCPSocketBinaryType,
-  TCPServerSocketEventAPI,
-  ErrorEventAPI
-} from "gecko"
-import type {
-  API,
-  ServerOptions,
-  ServerSocket,
-
-  ClientOptions,
-  ClientSocket,
-
-  Status,
-} from "../interface/tcp"
-
-interface Host {
-  +TCPSocket: API;
+const AsAsyncIterator = constructor => {
+  const $Symbol /*:any*/ = Symbol
+  const prototype /*:Object*/ = constructor.prototype
+  prototype[$Symbol.asyncIterator] = function() {
+    return this
+  }
+  return constructor
 }
-*/
-Cu.importGlobalProperties(["URL"])
 
-{
-  const { Services } = Cu.import("resource://gre/modules/Services.jsm", {})
-  const { OS } = Cu.import("resource://gre/modules/osfile.jsm", {})
-  const { TCPSocket, TCPServerSocket } = Cu.getGlobalForObject(OS)
-  const { ExtensionUtils } = Cu.import(
-    "resource://gre/modules/ExtensionUtils.jsm",
-    {}
-  )
-  const env = Cc["@mozilla.org/process/environment;1"].getService(
-    Ci.nsIEnvironment
-  )
+const exportClass = /*::<b, a:Class<b>>*/ (
+  scope /*:Object*/,
+  constructor /*:a*/
+) /*:a*/ => {
+  const clone = Cu.exportFunction(constructor, scope)
+  const unwrapped = Cu.waiveXrays(clone)
+  const prototype = Cu.waiveXrays(Cu.createObjectIn(scope))
 
-  // const url = Components.stack.filename.split("->").pop()
-  // const { TCPSocketAdapter, TCPServerSocketAdapter } = Cu.import(
-  //   new URL(`./TCP.js`, url),
-  //   {}
-  // )
-
-  const { ExtensionError } = ExtensionUtils
-
-  const AsAsyncIterator = constructor => {
-    const $Symbol /*:any*/ = Symbol
-    const prototype /*:Object*/ = constructor.prototype
-    prototype[$Symbol.asyncIterator] = function() {
-      return this
-    }
-    return constructor
-  }
-
-  class IOError extends ExtensionError {
-    static throw(message) /*:empty*/ {
-      const self = new this(message)
-      throw self
-    }
-  }
-
-  const wrapUnprivilegedFunction = (f, scope) => input =>
-    f(Cu.cloneInto(input, scope))
-
-  class Server {
-    /*::
-    socket:TCPServerSocketAPI
-    closed:Promise<void>
-    onerrored:(Error) => void
-    onclosed:() => void
-    context:BaseContext
-    connections:Connections
-    localPort:number
-    */
-    constructor(
-      socket /*:TCPServerSocketAPI*/,
-      localPort /*:number*/,
-      connections /*:Connections*/
-    ) {
-      this.socket = socket
-      this.localPort = localPort
-      this.connections = connections
-    }
-
-    closeImmediately() {
-      debug && console.log("terminate server")
-      this.close()
-      this.delete()
-    }
-    delete() {
-      delete this.socket
-      delete this.closed
-    }
-    static async new(options /*:ServerOptions*/) /*: Promise<Server>*/ {
-      try {
-        debug &&
-          console.log(
-            `TCPServerSocket.serve ${options.port} ${String(options.backlog)}`
-          )
-        const socket = new TCPServerSocketAdapter(
-          options.port,
-          { binaryType: "arraybuffer" },
-          options.backlog || undefined
-        )
-
-        debug && console.log(`new TCPServerSocket ${socket.localPort}`)
-        const connections = new Connections()
-        const server = new Server(socket, socket.localPort, connections)
-
-        socket.onconnect = event => connections.connect(event.socket)
-        server.closed = new Promise((resolve, reject) => {
-          server.onclosed = () => resolve()
-          socket.onerror = ({ name, message }) =>
-            reject(new Error(`${name}: ${message}`))
-        })
-
-        return server
-      } catch (error) {
-        return IOError.throw(error.message)
-      }
-    }
-    onclose(status /*:nsresult*/) {
-      this.onclosed()
-      this.connections.close()
-    }
-    onerror(status /*:nsresult*/) {
-      const error = new Error(status)
-      this.connections.close(error)
-      this.onerrored(error)
-    }
-    close() {
-      this.socket.close()
-      this.onclose(Cr.NS_OK)
-    }
-  }
-
-  class Connections {
-    /*::
-    requests:{resolve(?TCPSocketAPI):void, reject(Error):void}[]
-    */
-    constructor() {
-      this.requests = []
-    }
-    request(resolve, reject) {
-      this.requests.push({ resolve, reject })
-    }
-    connect(socket /*:TCPSocketAPI*/) {
-      const request = this.requests.shift()
-      if (request) {
-        request.resolve(socket)
-      } else {
-        socket.closeImmediately()
-      }
-    }
-    close(error) {
-      const { requests } = this
-      while (requests.length) {
-        const request = requests.shift()
-        if (error) {
-          request.reject(error)
-        } else {
-          request.resolve()
-        }
-      }
-    }
-  }
-
-  global.TCPSocket = class extends ExtensionAPI /*::<Host>*/ {
-    getAPI(context) {
-      const servers = new WeakMap()
-      const clients = new WeakMap()
-      const connections = new WeakMap()
-      const sockets = new Set()
-
-      context.callOnClose({
-        close() {
-          debug && console.log(`TCPSocket API unload ${sockets.size}`)
-          for (const socket of sockets) {
-            socket.closeImmediately()
-          }
-        }
-      })
-
-      const deref = /*::<a, b>*/ (
-        refs /*:WeakMap<a, b>*/,
-        handle /*:a*/
-      ) /*:b*/ => {
-        const ref = refs.get(handle)
-        if (!ref) {
-          return IOError.throw("Unable to find corresponding socket")
-        } else {
-          return ref
-        }
-      }
-
-      const derefServer = handle => deref(servers, handle)
-      const derefSocket = handle => deref(clients, handle)
-      const derefConnections = handle => deref(connections, handle)
-
-      const TCPClient = exportClass(
-        context.cloneScope,
-        class TCPClient {
-          /*::
-          opened:Promise<void>
-          closed:Promise<void>
-          */
-          constructor() {
-            throw TypeError("Illegal constructor")
-          }
-          get host() {
-            return derefSocket(this).host
-          }
-          get port() {
-            return derefSocket(this).port
-          }
-          get ssl() {
-            return derefSocket(this).ssl
-          }
-          get readyState() {
-            return derefSocket(this).readyState
-          }
-          get bufferedAmount() {
-            return derefSocket(this).bufferedAmount
-          }
-          write(buffer, byteOffset, byteLength) {
-            const socket = derefSocket(this)
-            if (socket.send(buffer, byteOffset, byteLength)) {
-              return voidPromise
-            } else {
-              return new context.cloneScope.Promise((resolve, reject) => {
-                socket.ondrain = () => resolve()
-                socket.onerror = ({ name, message }) =>
-                  reject(new IOError(`${name}: ${message}`))
-              })
-            }
-          }
-          read() {
-            return context.wrapPromise(
-              new Promise((resolve, reject) => {
-                derefSocket(this).ondata = event => resolve(event.data)
-              })
-            )
-          }
-          suspend() {
-            derefSocket(this).suspend()
-          }
-          resume() {
-            derefSocket(this).resume()
-          }
-          close() {
-            derefSocket(this).close()
-            return voidPromise
-          }
-          closeImmediately() {
-            derefSocket(this).closeImmediately()
-            return voidPromise
-          }
-          upgradeToSecure() {
-            return derefSocket(this).upgradeToSecure()
-          }
-        }
-      )
-
-      const TCPConnections = exportClass(
-        context.cloneScope,
-        AsAsyncIterator(
-          class TCPConnections {
-            /*::
-            @@asyncIterator: () => self
-            // server:Server
-            */
-            constructor() {
-              throw TypeError("Illegal constructor")
-            }
-            next() {
-              return new context.cloneScope.Promise((resolve, reject) => {
-                const self = derefConnections(this)
-                self.request(socket => {
-                  if (socket) {
-                    resolve(next(createClientSocket(socket)))
-                  } else {
-                    resolve(done)
-                  }
-                }, reject)
-              })
-            }
-            return() {
-              derefConnections(this).close()
-              return done
-            }
-          }
-        )
-      )
-
-      const TCPServer = exportClass(
-        context.cloneScope,
-        class TCPServer {
-          /*::
-          connections:AsyncIterator<ClientSocket>
-          */
-          constructor() {
-            throw TypeError("Illegal constructor")
-          }
-          close() {
-            const server = derefServer(this)
-            server.close()
-            sockets.delete(server)
-            servers.delete(server)
-          }
-          get localPort() {
-            return derefServer(this).localPort
-          }
-          get closed() {
-            return context.wrapPromise(derefServer(this).closed)
-          }
-        }
-      )
-
-      const voidPromise = context.cloneScope.Promise.resolve()
-      const done = Cu.cloneInto({ done: true }, context.cloneScope)
-      const next = value => {
-        const result = Cu.cloneInto({ done: false }, context.cloneScope)
-        Reflect.defineProperty(result, "value", { value })
-        return result
-      }
-
-      const createClientSocket = (
-        socket /*:TCPSocketAPI*/
-      ) /*:ClientSocket*/ => {
-        const client = exportInstance(context.cloneScope, TCPClient)
-        clients.set(client, socket)
-        sockets.add(socket)
-
-        client.opened =
-          socket.readyState === "open"
-            ? voidPromise
-            : new context.cloneScope.Promise((resolve, reject) => {
-                socket.onopen = () => resolve()
-              })
-
-        client.closed = context.wrapPromise(
-          new Promise((resolve, reject) => {
-            socket.onclose = () => resolve()
-            socket.onerror = event =>
-              reject(new IOError(`${event.name}: ${event.message}`))
+  const source = constructor.prototype
+  for (const key of Reflect.ownKeys(constructor.prototype)) {
+    if (key !== "constructor") {
+      const descriptor = Reflect.getOwnPropertyDescriptor(source, key)
+      Reflect.defineProperty(
+        prototype,
+        key,
+        Cu.waiveXrays(
+          Cu.cloneInto(descriptor, scope, {
+            cloneFunctions: true
           })
         )
+      )
+    }
+  }
 
-        return client
-      }
+  Reflect.defineProperty(unwrapped, "prototype", {
+    value: prototype
+  })
+  Reflect.defineProperty(prototype, "constructor", {
+    value: unwrapped
+  })
 
-      const createConnections = () /*:TCPConnections*/ =>
-        exportInstance(context.cloneScope, TCPConnections)
+  return clone
+}
 
-      const createServerSocket = () /*:ServerSocket*/ => {
-        const connections = createConnections()
-        const server = exportInstance(context.cloneScope, TCPServer)
-        Reflect.defineProperty(server, "connections", { value: connections })
-        return server
-      }
+const exportInstance = /*::<a:Object, b:a>*/ (
+  scope,
+  constructor /*:Class<b>*/,
+  properties /*::?:a*/
+) /*:b*/ => {
+  const instance /*:any*/ = properties
+    ? Cu.cloneInto(properties, scope)
+    : Cu.cloneInto({}, scope)
+  Reflect.setPrototypeOf(
+    Cu.waiveXrays(instance),
+    Cu.waiveXrays(constructor).prototype
+  )
+  return instance
+}
 
-      return {
-        TCPSocket: {
-          listen: options =>
-            new context.cloneScope.Promise(async (resolve, reject) => {
-              try {
-                const socket = createServerSocket()
-                const server = await Server.new(options)
+global.TCPSocket = class extends ExtensionAPI /*::<Host>*/ {
+  getAPI(context) {
+    const servers = new Map()
+    const connections = new Map()
+    const connectionInternal = new Map()
 
-                sockets.add(server)
-                connections.set(socket.connections, server.connections)
-                servers.set(socket, server)
+    const derefSocket = client => {
+      return connections.get(client.__id)
+    }
 
-                resolve(socket)
-              } catch (error) {
-                reject(error)
+    const TCPClient = exportClass(
+      context.cloneScope,
+      class TCPClient {
+        constructor() {
+          throw TypeError("Illegal constructor")
+        }
+        get host() {
+          return derefSocket(this).host
+        }
+        get port() {
+          return derefSocket(this).port
+        }
+        get ssl() {
+          return derefSocket(this).ssl
+        }
+        get readyState() {
+          return derefSocket(this).readyState
+        }
+        get bufferedAmount() {
+          return derefSocket(this).bufferedAmount
+        }
+        get opened() {
+          return derefSocket(this).opened
+        }
+        get closed() {
+          return derefSocket(this).closed
+        }
+        write(buffer, byteOffset, byteLength) {
+          return new context.cloneScope.Promise(async (resolve, reject) => {
+            try {
+              const result = await context.childManager.callParentAsyncFunction(
+                "TCPSocket.write",
+                [this.__id, buffer, byteOffset, byteLength]
+              )
+              resolve()
+            } catch (e) {
+              reject(e.toString())
+            }
+          })
+        }
+        read() {
+          return new context.cloneScope.Promise(async resolve => {
+            const internal = connectionInternal.get(this.__id)
+            if (internal.buffer.length > 0) {
+              resolve(internal.buffer.shift())
+            } else {
+              internal.ondata = () => {
+                resolve(internal.buffer.shift())
               }
-            }),
-          connect: options =>
-            new context.cloneScope.Promise(async (resolve, reject) => {
-              try {
-                const socket = new TCPSocket(options.host, options.port, {
-                  useSecureTransport: options.useSecureTransport,
-                  binaryType: "arraybuffer"
-                })
-
-                const client = createClientSocket(socket)
-                // await client.opened
-                resolve(client)
-              } catch (error) {
-                reject(error)
-              }
-            })
+            }
+          })
+        }
+        suspend() {
+          context.childManager.callParentAsyncFunction("TCPSocket.suspend", [
+            this.__id
+          ])
+        }
+        resume() {
+          context.childManager.callParentAsyncFunction("TCPSocket.resume", [
+            this.__id
+          ])
+        }
+        close() {
+          return new context.cloneScope.Promise(async resolve => {
+            await context.childManager.callParentAsyncFunction(
+              "TCPSocket.close",
+              [this.__id]
+            )
+            resolve()
+          })
+        }
+        closeImmediately() {
+          return new context.cloneScope.Promise(async resolve => {
+            await context.childManager.callParentAsyncFunction(
+              "TCPSocket.closeImmediately",
+              [this.__id]
+            )
+            resolve()
+          })
+        }
+        upgradeToSecure() {
+          context.childManager.callParentAsyncFunction(
+            "TCPSocket.upgradeToSecure",
+            [this.__id]
+          )
         }
       }
-    }
-  }
-
-  const exportClass = /*::<b, a:Class<b>>*/ (
-    scope /*:Object*/,
-    constructor /*:a*/
-  ) /*:a*/ => {
-    const clone = Cu.exportFunction(constructor, scope)
-    const unwrapped = Cu.waiveXrays(clone)
-    const prototype = Cu.waiveXrays(Cu.createObjectIn(scope))
-
-    const source = constructor.prototype
-    for (const key of Reflect.ownKeys(constructor.prototype)) {
-      if (key !== "constructor") {
-        const descriptor = Reflect.getOwnPropertyDescriptor(source, key)
-        Reflect.defineProperty(
-          prototype,
-          key,
-          Cu.waiveXrays(
-            Cu.cloneInto(descriptor, scope, {
-              cloneFunctions: true
-            })
-          )
-        )
-      }
-    }
-
-    Reflect.defineProperty(unwrapped, "prototype", {
-      value: prototype
-    })
-    Reflect.defineProperty(prototype, "constructor", {
-      value: unwrapped
-    })
-
-    return clone
-  }
-
-  const exportInstance = /*::<a:Object, b:a>*/ (
-    scope,
-    constructor /*:Class<b>*/,
-    properties /*::?:a*/
-  ) /*:b*/ => {
-    const instance /*:any*/ = properties
-      ? Cu.cloneInto(properties, scope)
-      : Cu.cloneInto({}, scope)
-    Reflect.setPrototypeOf(
-      Cu.waiveXrays(instance),
-      Cu.waiveXrays(constructor).prototype
     )
-    return instance
-  }
 
-  const SEC_ERROR_BASE = Ci.nsINSSErrorsService.NSS_SEC_ERROR_BASE
-  const SEC_ERROR_EXPIRED_CERTIFICATE = SEC_ERROR_BASE + 11
-  const SEC_ERROR_REVOKED_CERTIFICATE = SEC_ERROR_BASE + 12
-  const SEC_ERROR_UNKNOWN_ISSUER = SEC_ERROR_BASE + 13
-  const SEC_ERROR_UNTRUSTED_ISSUER = SEC_ERROR_BASE + 20
-  const SEC_ERROR_UNTRUSTED_CERT = SEC_ERROR_BASE + 21
-  const SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE = SEC_ERROR_BASE + 30
-  const SEC_ERROR_CA_CERT_INVALID = SEC_ERROR_BASE + 36
-  const SEC_ERROR_INADEQUATE_KEY_USAGE = SEC_ERROR_BASE + 90
-  const SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED = SEC_ERROR_BASE + 176
-
-  const SSL_ERROR_BASE = -0x3000
-  const SSL_ERROR_NO_CERTIFICATE = 3
-  const SSL_ERROR_BAD_CERTIFICATE = SSL_ERROR_BASE + 4
-  const SSL_ERROR_UNSUPPORTED_CERTIFICATE_TYPE = SSL_ERROR_BASE + 8
-  const SSL_ERROR_UNSUPPORTED_VERSION = SSL_ERROR_BASE + 9
-  const SSL_ERROR_BAD_CERT_DOMAIN = SSL_ERROR_BASE + 12
-
-  const BUFFER_SIZE = 65536
-
-  // Port of: https://github.com/mozilla/gecko-dev/blob/f51c4fa5d92d59fcb46f314e94edbf045cb3067c/dom/network/TCPServerSocket.cpp
-  class TCPServerSocketAdapter /*::implements TCPServerSocketAPI*/ {
-    /*::
-  onconnect: ?(TCPServerSocketEventAPI) => mixed;
-  onerror: ?(ErrorEventAPI) => mixed;
-  localPort: number;
-  serverSocket: ?nsIServerSocket;
-  */
-    constructor(port, options, backlog) {
-      const serverSocket = Cc[
-        "@mozilla.org/network/server-socket;1"
-      ].createInstance(Ci.nsIServerSocket)
-      serverSocket.init(port, false, backlog || -1)
-      this.serverSocket = serverSocket
-      this.localPort = serverSocket.port
-
-      serverSocket.asyncListen(this)
+    const done = Cu.cloneInto({ done: true }, context.cloneScope)
+    const next = value => {
+      const result = Cu.cloneInto({ done: false }, context.cloneScope)
+      Reflect.defineProperty(result, "value", { value })
+      return result
     }
-    close() {
-      debug && console.log("TPCServerSocketAdapter.close", this.serverSocket)
-      if (this.serverSocket) {
-        this.serverSocket.close()
+
+    const createClientSocket = (socket /*:TCPSocketAPI*/) /*:ClientSocket*/ => {
+      const internals = {
+        buffer: []
       }
+      socket.opened = new context.cloneScope.Promise(resolve => {
+        internals.onOpened = resolve
+      })
+      socket.closed = new context.cloneScope.Promise(resolve => {
+        internals.onClosed = resolve
+      })
+      connections.set(socket.id, socket)
+      connectionInternal.set(socket.id, internals)
+
+      const client = exportInstance(context.cloneScope, TCPClient, {
+        __id: socket.id
+      })
+      return client
     }
 
-    // nsIServerSocketListener
-    onSocketAccepted(server, transport) {
-      const socket = TCPSocketAdapter.createAcceptedSocket(transport)
-      TCPServerSocketAdapter.fireEvent(this, "connect", socket)
-    }
-    onStopListening(server, status) {
-      this.serverSocket = null
-      switch (status) {
-        case Cr.NS_BINDING_ABORTED: {
-          break
-        }
-        default: {
-          TCPServerSocketAdapter.fireErrorEvent(
-            this,
-            "NetworkError",
-            "Server socket was closed by unexpected reason."
-          )
-        }
-      }
-    }
-
-    // Statics
-    static fireEvent(self, type, socket /*:TCPSocketAPI*/) {
-      switch (type) {
-        case "connect": {
-          if (self.onconnect) {
-            self.onconnect({
-              type: "connect",
-              socket
+    const TCPConnections = exportClass(
+      context.cloneScope,
+      AsAsyncIterator(
+        class TCPConnections {
+          constructor() {
+            throw TypeError("Illegal constructor")
+          }
+          next() {
+            return new context.cloneScope.Promise(async (resolve, reject) => {
+              try {
+                const socket = await context.childManager.callParentAsyncFunction(
+                  "TCPSocket.pollServer",
+                  [this.__id]
+                )
+                if (socket) {
+                  resolve(next(createClientSocket(socket)))
+                } else {
+                  resolve(done)
+                }
+              } catch (e) {
+                reject(e.toString())
+              }
             })
           }
-          break
-        }
-      }
-    }
-    static fireErrorEvent(self, name, message) {
-      if (self.onerror) {
-        self.onerror({
-          type: "error",
-          name,
-          message
-        })
-      }
-    }
-  }
-
-  // Port of: https://github.com/mozilla/gecko-dev/blob/f51c4fa5d92d59fcb46f314e94edbf045cb3067c/dom/network/TCPSocket.cpp#L411
-  const DO_NOT_INIT = {}
-  const ASYNC_COPY = { type: "asyncCopy" }
-  const ASYNC_READ = { type: "asyncRead" }
-
-  class TCPSocketAdapter /*::implements TCPSocketAPI*/ {
-    /*::
-    host:string;
-    port:number;
-    binaryType: TCPSocketBinaryType;
-    bufferedAmount:number;
-    transport:nsISocketTransport;
-    readyState:TCPReadyState;
-    ssl:boolean;
-    socketInputStream:?nsIInputStream
-    socketOutputStream:?nsIOutputStream
-    binaryInputStream:nsIBinaryInputStream
-    inputStreamPump:?nsIInputStreamPump
-    suspendCount:number
-    asyncCopierActive:boolean
-    waitingForDrain:boolean
-    waitingForStartTLS:boolean
-    pendingData:nsIInputStream[]
-    pendingDataAfterStartTLS:nsIInputStream[]
-    copyObserver:nsIRequestObserver
-
-    onopen:?({type:"open"}) => mixed
-    onclose:?({type:"close"}) => mixed
-    ondrain:?({type:"drain"}) => mixed
-    ondata:?({type:"data", data:ArrayBuffer}) => mixed
-    onerror:?(ErrorEventAPI) => mixed
-    */
-    constructor(
-      host /*:string*/,
-      port /*:number*/,
-      options /*::?:SocketOptions*/
-    ) {
-      this.host = host
-      this.port = port
-      this.ssl = options && options.useSecureTransport ? true : false
-      this.readyState = "closed"
-      this.asyncCopierActive = false
-      this.waitingForDrain = false
-      this.bufferedAmount = 0
-      this.suspendCount = 0
-      this.waitingForStartTLS = false
-      this.pendingData = []
-      this.pendingDataAfterStartTLS = []
-      this.binaryType = "arraybuffer"
-      this.copyObserver = new CopierObserver(this)
-
-      if (options !== DO_NOT_INIT) {
-        TCPSocketAdapter.init(this)
-      }
-    }
-    static createAcceptedSocket(transport /*:nsISocketTransport*/) {
-      const self = new TCPSocketAdapter(
-        transport.host,
-        transport.port,
-        DO_NOT_INIT
-      )
-      self.transport = transport
-
-      TCPSocketAdapter.createStream(self)
-      TCPSocketAdapter.createInputStreamPump(self)
-      self.readyState = "open"
-
-      return self
-    }
-    static init(self) {
-      self.readyState = "connecting"
-      const transportService = Cc[
-        "@mozilla.org/network/socket-transport-service;1"
-      ].getService(Ci.nsISocketTransportService)
-      const socketTypes = self.ssl ? ["ssl"] : ["starttls"]
-      const transport = transportService.createTransport(
-        socketTypes,
-        1,
-        self.host,
-        self.port,
-        null
-      )
-      TCPSocketAdapter.initWithUnconnectedTransport(self, transport)
-    }
-    static initWithUnconnectedTransport(self, transport) {
-      self.readyState = "connecting"
-      self.transport = transport
-      transport.setEventSink(self, null)
-      TCPSocketAdapter.createStream(self)
-    }
-    static createStream(self) {
-      const { transport } = self
-      const socketInputStream = transport.openInputStream(0, 0, 0)
-      const socketOutputStream = transport.openOutputStream(
-        Ci.nsITransport.OPEN_UNBUFFERED,
-        0,
-        0
-      )
-      const asyncStream = socketInputStream.QueryInterface(
-        Ci.nsIAsyncInputStream
-      )
-
-      asyncStream.asyncWait(
-        self,
-        Ci.nsIAsyncInputStream.WAIT_CLOSURE_ONLY,
-        0,
-        null
-      )
-      const binaryInputStream = Cc[
-        "@mozilla.org/binaryinputstream;1"
-      ].createInstance(Ci.nsIBinaryInputStream)
-      binaryInputStream.setInputStream(socketInputStream)
-
-      self.binaryInputStream = binaryInputStream
-      self.socketInputStream = socketInputStream
-      self.socketOutputStream = socketOutputStream
-    }
-    static createInputStreamPump(self) {
-      const { socketInputStream } = self
-      if (!socketInputStream) {
-        return IOError.throw(Cr.NS_ERROR_NOT_AVAILABLE)
-      }
-      const inputStreamPump = Cc[
-        "@mozilla.org/network/input-stream-pump;1"
-      ].createInstance(Ci.nsIInputStreamPump)
-      inputStreamPump.init(socketInputStream, 0, 0, false, null)
-
-      while (self.suspendCount--) {
-        inputStreamPump.suspend()
-      }
-      inputStreamPump.asyncRead(self, null)
-    }
-    static maybeReportErrorAndCloseIfOpen(self, status) {
-      if (self.readyState === "closed") {
-        return undefined
-      }
-      self.close()
-      self.readyState = "closed"
-
-      if (status !== Cr.NS_OK) {
-        let errorType = "SecurityProtocol"
-        let errorName = "SecurityError"
-
-        // security module? (and this is an error)
-        if ((status & 0xff0000) === 0x5a0000) {
-          const errorService = Cc[
-            "@mozilla.org/nss_errors_service;1"
-          ].getService(Ci.nsINSSErrorsService)
-          try {
-            // getErrorClass will throw a generic NS_ERROR_FAILURE if the error code is
-            // somehow not in the set of covered errors.
-            const errorClass = errorService.getErrorClass(status)
-            switch (errorClass) {
-              case Ci.nsINSSErrorsService.ERROR_CLASS_BAD_CERT: {
-                errorType = "SecurityCertificate"
-                break
-              }
-              default: {
-                break
-              }
-            }
-          } catch (_) {}
-
-          // NSS_SEC errors (happen below the base value because of negative vals)
-          if (
-            (status & 0xffff) <
-            Math.abs(Ci.nsINSSErrorsService.NSS_SEC_ERROR_BASE)
-          ) {
-            switch (status) {
-              case SEC_ERROR_EXPIRED_CERTIFICATE:
-                errorName = "SecurityExpiredCertificateError"
-                break
-              case SEC_ERROR_REVOKED_CERTIFICATE:
-                errorName = "SecurityRevokedCertificateError"
-                break
-              case SEC_ERROR_UNKNOWN_ISSUER:
-              case SEC_ERROR_UNTRUSTED_ISSUER:
-              case SEC_ERROR_UNTRUSTED_CERT:
-              case SEC_ERROR_CA_CERT_INVALID:
-                errorName = "SecurityUntrustedCertificateIssuerError"
-                break
-              case SEC_ERROR_INADEQUATE_KEY_USAGE:
-                errorName = "SecurityInadequateKeyUsageError"
-                break
-              case SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED:
-                errorName = "SecurityCertificateSignatureAlgorithmDisabledError"
-                break
-              default:
-                break
-            }
-          } else {
-            switch (status) {
-              case SSL_ERROR_NO_CERTIFICATE:
-                errorName = "SecurityNoCertificateError"
-                break
-              case SSL_ERROR_BAD_CERTIFICATE:
-                errorName = "SecurityBadCertificateError"
-                break
-              case SSL_ERROR_UNSUPPORTED_CERTIFICATE_TYPE:
-                errorName = "SecurityUnsupportedCertificateTypeError"
-                break
-              case SSL_ERROR_UNSUPPORTED_VERSION:
-                errorName = "SecurityUnsupportedTLSVersionError"
-                break
-              case SSL_ERROR_BAD_CERT_DOMAIN:
-                errorName = "SecurityCertificateDomainMismatchError"
-                break
-              default:
-                break
-            }
-          }
-        } else {
-          errorType = "Network"
-          switch (status) {
-            case Cr.NS_ERROR_CONNECTION_REFUSED: {
-              errorName = "ConnectionRefusedError"
-              break
-            }
-            case Cr.NS_ERROR_NET_TIMEOUT: {
-              errorName = "NetworkTimeoutError"
-              break
-            }
-            case Cr.NS_ERROR_UNKNOWN_HOST: {
-              errorName = "DomainNotFoundError"
-              break
-            }
-            case Cr.NS_ERROR_NET_INTERRUPT: {
-              errorName = "NetworkInterruptError"
-              break
-            }
-            default: {
-              errorName = "NetworkError"
-              break
-            }
+          return() {
+            context.childManager.callParentAsyncFunction(
+              "TCPSocket.closeServer",
+              [this.__id]
+            )
+            return done
           }
         }
-
-        TCPSocketAdapter.fireErrorEvent(self, errorName, errorType)
-      }
-      TCPSocketAdapter.fireEvent(self, "close")
-    }
-    static fireErrorEvent(self, name, type) {
-      const { onerror } = self
-      if (onerror) {
-        onerror({ type: "error", name, message: type })
-      }
-    }
-    static fireEvent(self, type) {
-      const event = { type }
-      switch (type) {
-        case "close": {
-          const handler = self.onclose
-          if (handler) {
-            handler({ type: "close" })
-          }
-          break
-        }
-        case "open": {
-          const handler = self.onopen
-          if (handler) {
-            handler({ type: "open" })
-          }
-          break
-        }
-        case "drain": {
-          const handler = self.ondrain
-          if (handler) {
-            handler({ type: "drain" })
-          }
-          break
-        }
-      }
-    }
-    static fireDataEvent(self, buffer) {
-      const { ondata } = self
-      if (ondata) {
-        ondata({ type: "data", data: buffer })
-      }
-    }
-    static close(self, waitForUnsentData /*:boolean*/) {
-      if (self.readyState === "closed" || self.readyState === "closing") {
-        return undefined
-      }
-      self.readyState = "closing"
-      if (self.asyncCopierActive || !waitForUnsentData) {
-        self.pendingData.splice(0)
-        self.pendingDataAfterStartTLS.splice(0)
-
-        const { socketOutputStream, socketInputStream } = self
-        if (socketOutputStream) {
-          socketOutputStream.close()
-          self.socketOutputStream = null
-          delete self.binaryInputStream
-        }
-
-        if (socketInputStream) {
-          socketInputStream.close()
-          self.socketInputStream = null
-        }
-      }
-    }
-    static send(self, stream, byteLength) {
-      debug && console.log(`TCPSocketAdapter.send ${stream.available()}`)
-      self.bufferedAmount += byteLength
-      const isBufferFull = self.bufferedAmount > BUFFER_SIZE
-      if (isBufferFull) {
-        self.waitingForDrain = true
-      }
-
-      if (self.waitingForStartTLS) {
-        self.pendingDataAfterStartTLS.push(stream)
-      } else {
-        self.pendingData.push(stream)
-      }
-      TCPSocketAdapter.ensureCopying(self)
-
-      return !isBufferFull
-    }
-    static ensureCopying(self) {
-      const { socketOutputStream, asyncCopierActive } = self
-
-      if (asyncCopierActive || !socketOutputStream) {
-        return
-      }
-      self.asyncCopierActive = true
-      const multiplexStream = Cc[
-        "@mozilla.org/io/multiplex-input-stream;1"
-      ].createInstance(Ci.nsIMultiplexInputStream)
-
-      const multiplex$inputStream /*:nsISupports<nsIInputStream>*/ = multiplexStream
-      const stream = multiplex$inputStream.QueryInterface(Ci.nsIInputStream)
-
-      while (self.pendingData.length > 0) {
-        const stream = self.pendingData.shift()
-        multiplexStream.appendStream(stream)
-      }
-
-      const copier = Cc[
-        "@mozilla.org/network/async-stream-copier;1"
-      ].createInstance(Ci.nsIAsyncStreamCopier)
-      const socketTransportService = Cc[
-        "@mozilla.org/network/socket-transport-service;1"
-      ].getService(Ci.nsISocketTransportService)
-
-      const $target /*:nsISupports<nsIEventTarget>*/ = socketTransportService
-      const target = $target.QueryInterface(Ci.nsIEventTarget)
-
-      debug &&
-        console.log(
-          `TCPSocketAdapter.ensureCopying copy ${stream.available()} bytes`
-        )
-
-      copier.init(
-        stream,
-        socketOutputStream,
-        target,
-        true,
-        false,
-        BUFFER_SIZE,
-        false,
-        false
       )
+    )
 
-      copier.asyncCopy(self.copyObserver, null)
-    }
-    static notifyCopyComplete(self, status) {
-      debug && console.log(`TCPSocketAdapter.notifyCopyComplete ${status}`)
-      self.asyncCopierActive = false
-      let bufferedAmount = 0
-      for (const stream of self.pendingData) {
-        bufferedAmount += stream.available()
-      }
-      self.bufferedAmount = bufferedAmount
-
-      if (status !== Cr.NS_OK) {
-        return TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(self, status)
-      }
-
-      if (bufferedAmount > 0) {
-        return TCPSocketAdapter.ensureCopying(self)
-      }
-
-      // Maybe we have some empty stream. We want to have an empty queue now.
-      self.pendingData.splice(0)
-      // If we are waiting for initiating starttls, we can begin to
-      // activate tls now.
-      if (self.waitingForStartTLS && self.readyState === "open") {
-        TCPSocketAdapter.activateTLS(self)
-        self.waitingForStartTLS = false
-        // If we have pending data, we should send them, or fire
-        // a drain event if we are waiting for it.
-        if (self.pendingDataAfterStartTLS.length !== 0) {
-          self.pendingData = self.pendingDataAfterStartTLS
-          return TCPSocketAdapter.ensureCopying(self)
+    const TCPServer = exportClass(
+      context.cloneScope,
+      class TCPServer {
+        /*::
+        connections:AsyncIterator<ClientSocket>
+        */
+        constructor() {
+          throw TypeError("Illegal constructor")
         }
-      }
-
-      if (self.waitingForDrain) {
-        self.waitingForDrain = false
-        TCPSocketAdapter.fireEvent(self, "drain")
-      }
-
-      if (self.readyState === "closing") {
-        const { socketOutputStream } = self
-        if (socketOutputStream) {
-          socketOutputStream.close()
-          self.socketOutputStream = null
+        get localPort() {
+          return servers.get(this.__id).localPort
         }
-        self.readyState = "closed"
-        delete self.copyObserver
-        TCPSocketAdapter.fireEvent(self, "close")
-      }
-    }
-    static activateTLS(self) {
-      const { securityInfo } = self.transport
-      const socketControl = securityInfo.QueryInterface(Ci.nsISSLSocketControl)
-      if (socketControl) {
-        socketControl.StartTLS()
-        self.ssl = true
-      }
-    }
-
-    onTransportStatus(transport, status, progress, max) {
-      this.readyState = "open"
-      TCPSocketAdapter.createInputStreamPump(self)
-      TCPSocketAdapter.fireEvent(self, "open")
-    }
-    onStartRequest(request, context) {}
-    onDataAvailable(request, stream /*:nsIInputStream*/, offset, size) {
-      const buffer = new ArrayBuffer(size)
-      this.binaryInputStream.readArrayBuffer(size, buffer)
-      TCPSocketAdapter.fireDataEvent(this, buffer)
-    }
-    onStopRequest(request, status) {
-      debug && console.log(`TCPSocketAdapter.notifyReadComplete ${status}`)
-      this.inputStreamPump = null
-      if (this.asyncCopierActive && status === Cr.NS_OK) {
-        // If we have some buffered output still, and status is not an
-        // error, the other side has done a half-close, but we don't
-        // want to be in the close state until we are done sending
-        // everything that was buffered. We also don't want to call onclose
-        // yet.
-        return undefined
-      } else {
-        return TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(this, status)
-      }
-    }
-    onInputStreamReady(asyncStream /*:nsIAsyncInputStream*/) /*:void*/ {
-      // Only used for detecting if the connection was refused.
-      try {
-        const available = asyncStream.available()
-        debug &&
-          console.log(
-            `TCPSocketAdapter.onInputStreamReady available: ${available}`
+        get closed() {
+          return servers.get(this.__id).closed
+        }
+        get connections() {
+          const connections = exportInstance(
+            context.cloneScope,
+            TCPConnections,
+            { __id: this.__id }
           )
-      } catch (error) {
-        debug &&
-          console.log(
-            `TCPSocketAdapter.onInputStreamReady unavailable: ${error}`
+          return connections
+        }
+        close() {
+          context.childManager.callParentAsyncFunction(
+            "TCPSocket.closeServer",
+            [this.__id]
           )
-        TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(this, error)
+        }
       }
-    }
+    )
 
-    send(
-      buffer /*:ArrayBuffer*/,
-      byteOffset /*:number*/ = 0,
-      byteLength = buffer.byteLength
-    ) {
-      if (this.readyState !== "open") {
-        return IOError.throw("Socket is not open")
-      }
-      const stream = Cc[
-        "@mozilla.org/io/arraybuffer-input-stream;1"
-      ].createInstance(Ci.nsIArrayBufferInputStream)
-      stream.setData(buffer, byteOffset, byteLength)
-      return TCPSocketAdapter.send(this, stream, byteLength)
+    const pollEvents = async () => {
+      const events = await context.childManager.callParentAsyncFunction(
+        "TCPSocket.pollEventQueue",
+        []
+      )
+      events.forEach(event => {
+        const type = event[0]
+
+        if (type === "serverClose") {
+          const server = servers.get(event[1])
+          server.onClosed()
+          return
+        }
+
+        const socket = Object.assign(connections.get(event[1].id), event[1])
+        const internal = connectionInternal.get(event[1].id)
+        connections.set(socket.id, socket)
+        switch (type) {
+          case "open":
+            internal.onOpened()
+            break
+          case "close":
+            internal.onClosed()
+            break
+          case "data":
+            internal.buffer.push(event[2])
+            if (internal.ondata) {
+              internal.ondata()
+              internal.ondata = null
+            }
+            break
+        }
+      })
+      pollEvents()
     }
-    suspend() {}
-    resume() {}
-    close() {
-      TCPSocketAdapter.close(this, true)
-    }
-    closeImmediately() {
-      TCPSocketAdapter.close(this, false)
-    }
-    upgradeToSecure() {
-      if (this.readyState !== "open") {
-        return IOError.throw(Cr.NS_ERROR_FAILURE)
-      }
-      if (!this.ssl) {
-        return
-      }
-      if (!this.asyncCopierActive) {
-        TCPSocketAdapter.activateTLS(this)
-      } else {
-        this.waitingForStartTLS = true
+    pollEvents()
+
+    return {
+      TCPSocket: {
+        listen: options =>
+          new context.cloneScope.Promise(async (resolve, reject) => {
+            try {
+              const parentServer = await context.childManager.callParentAsyncFunction(
+                "TCPSocket.listen",
+                [options]
+              )
+
+              const internals = {
+                localPort: parentServer.localPort,
+                connections: []
+              }
+              internals.closed = new context.cloneScope.Promise(resolve => {
+                internals.onClosed = resolve
+              })
+              servers.set(parentServer.id, internals)
+              const server = exportInstance(context.cloneScope, TCPServer, {
+                __id: parentServer.id
+              })
+              resolve(server)
+            } catch (e) {
+              reject(e)
+            }
+          }),
+        connect: options =>
+          new context.cloneScope.Promise(async (resolve, reject) => {
+            try {
+              const socket = await context.childManager.callParentAsyncFunction(
+                "TCPSocket.connect",
+                [options]
+              )
+              resolve(createClientSocket(socket))
+            } catch (e) {
+              reject(e)
+            }
+          })
       }
     }
   }
-
-  class CopierObserver {
-    /*::
-    owner:TCPSocketAdapter
-    */
-    constructor(socket) {
-      this.owner = socket
-    }
-    onStartRequest(request) {}
-    onStopRequest(request, status) {
-      TCPSocketAdapter.notifyCopyComplete(this.owner, status)
-    }
-  }
-
-  const debug = env.get("MOZ_ENV") === "DEBUG"
 }

--- a/src/toolkit/components/extensions/child/ext-udp.js
+++ b/src/toolkit/components/extensions/child/ext-udp.js
@@ -20,28 +20,7 @@ interface Host {
 Cu.importGlobalProperties(["URL"])
 
 {
-  const { Services } = Cu.import("resource://gre/modules/Services.jsm", {})
-  const { OS } = Cu.import("resource://gre/modules/osfile.jsm", {})
-  const { ExtensionUtils } = Cu.import(
-    "resource://gre/modules/ExtensionUtils.jsm",
-    {}
-  )
-
-  const { ExtensionError } = ExtensionUtils
-
-  const $Symbol /*:any*/ = Symbol
-
-  class IOError extends ExtensionError {
-    static throw(message) /*:empty*/ {
-      const self = new this(message)
-      throw self
-    }
-  }
-
-  const wrapUnprivilegedFunction = (f, scope) => input =>
-    f(Cu.cloneInto(input, scope))
-
-  const getAPIClasses = (context, refs, sockets) => {
+  const getAPIClasses = context => {
     class UDPSocketClient /*::implements UDPSocket*/ {
       /*::
       address:SocketAddress
@@ -50,14 +29,17 @@ Cu.importGlobalProperties(["URL"])
         throw TypeError("Illegal constructor")
       }
       close() {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          sockets.delete(socket)
-          socket.close()
-          return voidPromise
-        } else {
-          throw notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            await context.childManager.callParentAsyncFunction(
+              "UDPSocket.close",
+              [this.__id]
+            )
+            resolve()
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
       send(
         host /*: string*/,
@@ -65,74 +47,83 @@ Cu.importGlobalProperties(["URL"])
         data /*: ArrayBuffer*/,
         size /*::?: number*/
       ) /*: Promise<number>*/ {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          const n = socket.send(
-            host,
-            port,
-            new Uint8Array(data),
-            size || data.byteLength
-          )
-          return context.cloneScope.Promise.resolve(n)
-        } else {
-          return notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            const result = await context.childManager.callParentAsyncFunction(
+              "UDPSocket.send",
+              [this.__id, host, port, data, size]
+            )
+            resolve(result)
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
       messages() {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          const host = new MessagesHost(socket)
-          const client = exportInstance(context.cloneScope, Messages)
-          refs.messages.set(client, host)
-          socket.asyncListen(host)
-          return client
-        } else {
-          return notFoundPromise()
-        }
+        const client = exportInstance(context.cloneScope, Messages, {
+          __socketId: this.__id
+        })
+        return client
       }
       setMulticastLoopback(flag /*:boolean*/) /*: Promise<void>*/ {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          socket.multicastLoopback = flag
-          return voidPromise
-        } else {
-          return notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            await context.childManager.callParentAsyncFunction(
+              "UDPSocket.setMulticastLoopback",
+              [this.__id, flag]
+            )
+            resolve()
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
       setMulticastInterface(
         multicastInterface /*:string*/
       ) /*: Promise<void>*/ {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          socket.multicastInterface = multicastInterface
-          return voidPromise
-        } else {
-          return notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            await context.childManager.callParentAsyncFunction(
+              "UDPSocket.setMulticastInterface",
+              [this.__id, multicastInterface]
+            )
+            resolve()
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
       joinMulticast(
         address /*: string*/,
         multicastInterface /*::?: string*/
       ) /*: Promise<void>*/ {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          socket.joinMulticast(address, multicastInterface)
-          return voidPromise
-        } else {
-          return notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            await context.childManager.callParentAsyncFunction(
+              "UDPSocket.joinMulticast",
+              [this.__id, address, multicastInterface]
+            )
+            resolve()
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
       leaveMulticast(
         address /*: string*/,
         multicastInterface /*::?: string*/
       ) /*: Promise<void>*/ {
-        const socket = refs.sockets.get(this)
-        if (socket) {
-          socket.leaveMulticast(address, multicastInterface)
-          return voidPromise
-        } else {
-          return notFoundPromise()
-        }
+        return new context.cloneScope.Promise(async (resolve, reject) => {
+          try {
+            await context.childManager.callParentAsyncFunction(
+              "UDPSocket.leaveMulticast",
+              [this.__id, address, multicastInterface]
+            )
+            resolve()
+          } catch (e) {
+            reject(e.message)
+          }
+        })
       }
     }
 
@@ -144,132 +135,16 @@ Cu.importGlobalProperties(["URL"])
         throw TypeError("Illegal constructor")
       }
       next() {
-        const host = refs.messages.get(this)
-        if (host) {
-          return host.next()
-        } else {
-          return notFoundPromise()
-        }
-      }
-      return() {
-        const host = refs.messages.get(this)
-        if (host) {
-          return host.return()
-        } else {
-          return notFoundPromise()
-        }
-      }
-    }
-
-    class MessagesHost {
-      /*::
-      socket:nsIUDPSocket
-      requests:{resolve({done:false, value:UDPMessage}|{done:true}):void, reject(Error):void}[]
-      responses:Promise<{done:false, value:UDPMessage}>[]
-      isDone:boolean
-      done:Promise<{done:true, value:void}>
-      scope:Object
-      */
-      constructor(socket) {
-        this.socket = socket
-        this.isDone = false
-        this.requests = []
-        this.responses = []
-        this.scope = context.cloneScope
-      }
-      onPacketReceived(socket, message) {
-        const { scope } = this
-        debug && console.log(`TCPSocket/onPacketReceived`, message)
-        const { address, port, family } = message.fromAddr
-        this.continue(
-          Cu.cloneInto(
-            [
-              message.rawData.buffer,
-              Cu.cloneInto({ address, port, family }, scope)
-            ],
-            scope
-          )
+        return context.childManager.callParentAsyncFunction(
+          "UDPSocket.pollMessages",
+          [this.__socketId]
         )
       }
-      onStopListening(socket, status) {
-        debug && console.log(`TCPSocket/onStopListening`, status)
-
-        if (status === Cr.NS_BINDING_ABORTED) {
-          return this.break()
-        } else {
-          return this.throw(
-            new Error(`Socket was closed with error: ${status}`)
-          )
-        }
-      }
-      continue(value) {
-        const { requests, isDone, responses, scope } = this
-        if (isDone) {
-          throw Error("Received message after iteration was done")
-        } else {
-          debug && console.log("UDPSocket.MessagesHost.continue", value)
-          const nextIteration = Cu.cloneInto(
-            { done: false /*::,value:value*/ },
-            context.cloneScope
-          )
-          Reflect.defineProperty(Cu.unwaiveXrays(nextIteration), "value", {
-            value
-          })
-
-          const request = requests.shift()
-          if (request) {
-            request.resolve(nextIteration)
-          } else {
-            responses.push(scope.Promise.resolve(nextIteration))
-          }
-        }
-      }
-      break() {
-        const { requests } = this
-        for (const request of requests) {
-          request.resolve(doneIteration)
-        }
-      }
-      throw(error) {
-        const { requests } = this
-        for (const request of requests) {
-          request.reject(error)
-        }
-      }
-      next() {
-        const { responses, requests, done, isDone } = this
-        const response = responses.shift()
-        if (response) {
-          return response
-        } else if (isDone) {
-          return done
-        } else {
-          return new context.cloneScope.Promise((resolve, reject) => {
-            requests.push({ resolve, reject })
-          })
-        }
-      }
       return() {
-        const { isDone, done } = this
-        if (!isDone) {
-          this.isDone = true
-          this.socket.close()
-        }
-        return doneIteration
-      }
-    }
-
-    const voidPromise /*:Promise<void>*/ = context.cloneScope.Promise.resolve()
-    const doneIteration = Cu.cloneInto({ done: true }, context.cloneScope)
-    const notFound = new ExtensionError("Host for the object not found")
-    let notFoundPromiseCache = null
-
-    const notFoundPromise = () => {
-      if (notFoundPromiseCache) {
-        return notFoundPromiseCache
-      } else {
-        notFoundPromiseCache = context.cloneScope.Promise.reject(notFound)
-        return notFoundPromiseCache
+        return context.childManager.callParentAsyncFunction(
+          "UDPSocket.returnHost",
+          [this.__socketId]
+        )
       }
     }
 
@@ -290,45 +165,25 @@ Cu.importGlobalProperties(["URL"])
       FAMILY_LOCAL: Ci.nsINetAddr.FAMILY_LOCAL,
 
       create: config =>
-        new context.cloneScope.Promise((resolve, reject) => {
+        new context.cloneScope.Promise(async (resolve, reject) => {
           const options = config || noOptions
+
           try {
-            const socket = Cc[
-              "@mozilla.org/network/udp-socket;1"
-            ].createInstance(Ci.nsIUDPSocket)
-
-            if (options.host != null) {
-              socket.init2(
-                options.host,
-                options.port || -1,
-                null,
-                options.addressReuse != false
-              )
-            } else {
-              socket.init(
-                options.port || -1,
-                options.loopbackOnly != false,
-                null,
-                options.addressReuse != false
-              )
-            }
-
-            const { address, port, family } = socket.localAddr
-            const client /*:UDPSocket*/ = exportInstance(
-              context.cloneScope,
-              api.UDPSocket,
-              {
-                address: Cu.cloneInto(
-                  { address, port, family },
-                  context.cloneScope
-                )
-              }
+            const socket = await context.childManager.callParentAsyncFunction(
+              "UDPSocket.create",
+              [options]
             )
-            sockets.add(socket)
-            refs.sockets.set(client, socket)
+            const client = exportInstance(context.cloneScope, api.UDPSocket, {
+              __id: socket.id,
+              address: {
+                address: socket.address,
+                port: socket.port,
+                family: socket.family
+              }
+            })
             resolve(client)
-          } catch (error) {
-            reject(new ExtensionError(error))
+          } catch (e) {
+            reject(e.message)
           }
         })
     }
@@ -341,15 +196,6 @@ Cu.importGlobalProperties(["URL"])
         messages: new WeakMap()
       }
       const sockets = new Set()
-
-      context.callOnClose({
-        close() {
-          for (const socket of sockets) {
-            socket.close()
-          }
-          sockets.clear()
-        }
-      })
 
       return { UDPSocket: getAPI(context, refs, sockets) }
     }
@@ -417,5 +263,4 @@ Cu.importGlobalProperties(["URL"])
   }
 
   const noOptions = {}
-  const debug = true
 }

--- a/src/toolkit/components/extensions/child/ext-udp.js
+++ b/src/toolkit/components/extensions/child/ext-udp.js
@@ -23,6 +23,7 @@ Cu.importGlobalProperties(["URL"])
   const getAPIClasses = context => {
     class UDPSocketClient /*::implements UDPSocket*/ {
       /*::
+      __id:Number
       address:SocketAddress
       */
       constructor() {
@@ -130,6 +131,7 @@ Cu.importGlobalProperties(["URL"])
     class MessagesClient {
       /*::
       @@asyncIterator: () => self
+      __socketId: Number
       */
       constructor() {
         throw TypeError("Illegal constructor")
@@ -156,8 +158,8 @@ Cu.importGlobalProperties(["URL"])
     }
   }
 
-  const getAPI = (context, refs, sockets) => {
-    const api = getAPIClasses(context, refs, sockets)
+  const getAPI = context => {
+    const api = getAPIClasses(context)
 
     return {
       FAMILY_INET: Ci.nsINetAddr.FAMILY_INET,
@@ -170,7 +172,7 @@ Cu.importGlobalProperties(["URL"])
 
           try {
             const socket = await context.childManager.callParentAsyncFunction(
-              "UDPSocket.create",
+              "UDPSocket.createSocket",
               [options]
             )
             const client = exportInstance(context.cloneScope, api.UDPSocket, {
@@ -191,13 +193,7 @@ Cu.importGlobalProperties(["URL"])
 
   global.UDPSocket = class extends ExtensionAPI /*::<Host>*/ {
     getAPI(context) {
-      const refs = {
-        sockets: new WeakMap(),
-        messages: new WeakMap()
-      }
-      const sockets = new Set()
-
-      return { UDPSocket: getAPI(context, refs, sockets) }
+      return { UDPSocket: getAPI(context) }
     }
   }
 

--- a/src/toolkit/components/extensions/parent/ext-tcp.js
+++ b/src/toolkit/components/extensions/parent/ext-tcp.js
@@ -1,0 +1,951 @@
+// @flow strict
+
+/*::
+import { Components, Cu, Cr, Ci, Cc, ExtensionAPI } from "gecko"
+import type {
+  BaseContext,
+  nsresult,
+  nsISupports,
+  nsISocketTransport,
+  nsIServerSocket,
+  TCPReadyState,
+  nsIInputStream,
+  nsIOutputStream,
+  nsIBinaryOutputStream,
+  nsIBinaryInputStream,
+  nsIAsyncInputStream,
+  nsIInputStreamPump,
+  nsIRequestObserver,
+  nsIEventTarget,
+
+  TCPServerSocketAPI,
+  TCPSocketAPI,
+  SocketOptions,
+  TCPSocketBinaryType,
+  TCPServerSocketEventAPI,
+  ErrorEventAPI
+} from "gecko"
+import type {
+  API,
+  ServerOptions,
+  ServerSocket,
+
+  ClientOptions,
+  ClientSocket,
+
+  Status,
+} from "../interface/tcp"
+
+interface Host {
+  +TCPSocket: API;
+}
+*/
+Cu.importGlobalProperties(["URL"])
+
+{
+  const { OS } = Cu.import("resource://gre/modules/osfile.jsm", {})
+  const { TCPSocket, TCPServerSocket } = Cu.getGlobalForObject(OS)
+  const { ExtensionUtils } = Cu.import(
+    "resource://gre/modules/ExtensionUtils.jsm",
+    {}
+  )
+  const env = Cc["@mozilla.org/process/environment;1"].getService(
+    Ci.nsIEnvironment
+  )
+
+  const { ExtensionError } = ExtensionUtils
+
+  class IOError extends ExtensionError {
+    static throw(message) /*:empty*/ {
+      const self = new this(message)
+      throw self
+    }
+  }
+
+  class Server {
+    /*::
+    socket:TCPServerSocketAPI
+    closed:Promise<void>
+    onerrored:(Error) => void
+    onclosed:() => void
+    context:BaseContext
+    connections:Connections
+    localPort:number
+    */
+    constructor(
+      socket /*:TCPServerSocketAPI*/,
+      localPort /*:number*/,
+      connections /*:Connections*/
+    ) {
+      this.socket = socket
+      this.localPort = localPort
+      this.connections = connections
+    }
+
+    closeImmediately() {
+      debug && console.log("terminate server")
+      this.close()
+      this.delete()
+    }
+    delete() {
+      delete this.socket
+      delete this.closed
+    }
+    static async new(options /*:ServerOptions*/) /*: Promise<Server>*/ {
+      try {
+        debug &&
+          console.log(
+            `TCPServerSocket.serve ${options.port} ${String(options.backlog)}`
+          )
+        const socket = new TCPServerSocketAdapter(
+          options.port,
+          { binaryType: "arraybuffer" },
+          options.backlog || undefined
+        )
+
+        debug && console.log(`new TCPServerSocket ${socket.localPort}`)
+        const connections = new Connections()
+        const server = new Server(socket, socket.localPort, connections)
+
+        socket.onconnect = event => connections.connect(event.socket)
+        server.closed = new Promise((resolve, reject) => {
+          server.onclosed = () => resolve()
+          socket.onerror = ({ name, message }) =>
+            reject(new Error(`${name}: ${message}`))
+        })
+
+        return server
+      } catch (error) {
+        return IOError.throw(error.message)
+      }
+    }
+    onclose(status /*:nsresult*/) {
+      this.onclosed()
+      this.connections.close()
+    }
+    onerror(status /*:nsresult*/) {
+      const error = new Error(status)
+      this.connections.close(error)
+      this.onerrored(error)
+    }
+    close() {
+      this.socket.close()
+      this.onclose(Cr.NS_OK)
+    }
+  }
+
+  class Connections {
+    /*::
+    requests:{resolve(?TCPSocketAPI):void, reject(Error):void}[]
+    */
+    constructor() {
+      this.requests = []
+    }
+    request(resolve, reject) {
+      this.requests.push({ resolve, reject })
+    }
+    connect(socket /*:TCPSocketAPI*/) {
+      const request = this.requests.shift()
+      if (request) {
+        request.resolve(socket)
+      } else {
+        socket.closeImmediately()
+      }
+    }
+    close(error) {
+      const { requests } = this
+      while (requests.length) {
+        const request = requests.shift()
+        if (error) {
+          request.reject(error)
+        } else {
+          request.resolve()
+        }
+      }
+    }
+  }
+
+  global.TCPSocket = class extends ExtensionAPI /*::<Host>*/ {
+    getAPI(context) {
+      const servers = new Map()
+      const clients = new Map()
+
+      context.callOnClose({
+        close() {
+          debug && console.log(`TCPSocket API unload ${clients.size}`)
+          for (const server of servers.values()) {
+            server.close()
+          }
+          for (const socket of clients.values()) {
+            socket.closeImmediately()
+          }
+        }
+      })
+
+      let serverIdx = 0
+      let connectionIdx = 0
+
+      let eventQueue = []
+      let pendingPoll = null
+
+      const emit = event => {
+        if (pendingPoll) {
+          pendingPoll(event)
+        } else {
+          eventQueue.push(event)
+        }
+      }
+
+      const serialiseSocket = (socket, id) => {
+        return {
+          id,
+          host: socket.host,
+          port: socket.port,
+          ssl: socket.ssl,
+          readyState: socket.readyState,
+          bufferedAmount: socket.bufferedAmount
+        }
+      }
+
+      return {
+        TCPSocket: {
+          listen: options =>
+            new context.cloneScope.Promise(async (resolve, reject) => {
+              try {
+                const id = ++serverIdx
+                const server = await Server.new(options)
+
+                servers.set(id, server)
+                server.closed.then(() => {
+                  emit(["serverClose", id])
+                  servers.delete(id)
+                })
+                resolve({
+                  id,
+                  localPort: server.localPort
+                })
+              } catch (error) {
+                reject(error.message)
+              }
+            }),
+          connect: options =>
+            new Promise(async (resolve, reject) => {
+              try {
+                const socket = new TCPSocket(options.host, options.port, {
+                  useSecureTransport: options.useSecureTransport,
+                  binaryType: "arraybuffer"
+                })
+
+                const client = serialiseSocket(socket, ++connectionIdx)
+                clients.set(client.id, socket)
+
+                socket.onopen = () => {
+                  emit(["open", serialiseSocket(socket, client.id)])
+                }
+                socket.onclose = () => {
+                  emit(["close", serialiseSocket(socket, client.id)])
+                  // cleanup the socket after 1s
+                  setTimeout(() => clients.delete(client.id), 1000)
+                }
+                socket.ondata = event => {
+                  emit(["data", serialiseSocket(socket, client.id), event.data])
+                }
+                resolve(client)
+              } catch (error) {
+                reject(error.message)
+              }
+            }),
+          pollEventQueue: () => {
+            return new context.cloneScope.Promise(resolve => {
+              if (eventQueue.length > 0) {
+                resolve(eventQueue)
+                eventQueue = []
+              } else {
+                pendingPoll = event => {
+                  resolve([event])
+                  eventQueue = []
+                  pendingPoll = null
+                }
+              }
+            })
+          },
+          write: (socketId, buffer, byteOffset, byteLength) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              const socket = clients.get(socketId)
+              if (socket.send(buffer, byteOffset, byteLength)) {
+                resolve()
+              } else {
+                socket.ondrain = resolve
+                socket.onerror = ({ name, message }) =>
+                  reject(new IOError(`${name}: ${message}`))
+              }
+            })
+          },
+          suspend: socketId => {
+            const socket = clients.get(socketId)
+            socket.suspend()
+          },
+          resume: socketId => {
+            const socket = clients.get(socketId)
+            socket.resume()
+          },
+          close: socketId => {
+            return new context.cloneScope.Promise(resolve => {
+              const socket = clients.get(socketId)
+              socket.close()
+              resolve()
+            })
+          },
+          closeImmediately: socketId => {
+            const socket = clients.get(socketId)
+            socket.closeImmediately()
+          },
+          upgradeToSecure: socketId => {
+            const socket = clients.get(socketId)
+            socket.upgradeToSecure()
+          },
+          closeServer: serverId => {
+            const server = servers.get(serverId)
+            server.close()
+            servers.delete(serverId)
+          },
+          pollServer: serverId => {
+            const server = servers.get(serverId)
+            return new context.cloneScope.Promise((resolve, reject) => {
+              server.connections.request(socket => {
+                if (socket) {
+                  const client = serialiseSocket(socket, ++connectionIdx)
+                  clients.set(client.id, socket)
+
+                  socket.onopen = () => {
+                    emit(["open", serialiseSocket(socket, client.id)])
+                  }
+                  socket.onclose = () => {
+                    emit(["close", serialiseSocket(socket, client.id)])
+                  }
+                  socket.ondata = event => {
+                    emit([
+                      "data",
+                      serialiseSocket(socket, client.id),
+                      event.data
+                    ])
+                  }
+                  resolve(client)
+                } else {
+                  resolve()
+                }
+              }, reject)
+            })
+          }
+        }
+      }
+    }
+  }
+
+  const SEC_ERROR_BASE = Ci.nsINSSErrorsService.NSS_SEC_ERROR_BASE
+  const SEC_ERROR_EXPIRED_CERTIFICATE = SEC_ERROR_BASE + 11
+  const SEC_ERROR_REVOKED_CERTIFICATE = SEC_ERROR_BASE + 12
+  const SEC_ERROR_UNKNOWN_ISSUER = SEC_ERROR_BASE + 13
+  const SEC_ERROR_UNTRUSTED_ISSUER = SEC_ERROR_BASE + 20
+  const SEC_ERROR_UNTRUSTED_CERT = SEC_ERROR_BASE + 21
+  const SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE = SEC_ERROR_BASE + 30
+  const SEC_ERROR_CA_CERT_INVALID = SEC_ERROR_BASE + 36
+  const SEC_ERROR_INADEQUATE_KEY_USAGE = SEC_ERROR_BASE + 90
+  const SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED = SEC_ERROR_BASE + 176
+
+  const SSL_ERROR_BASE = -0x3000
+  const SSL_ERROR_NO_CERTIFICATE = 3
+  const SSL_ERROR_BAD_CERTIFICATE = SSL_ERROR_BASE + 4
+  const SSL_ERROR_UNSUPPORTED_CERTIFICATE_TYPE = SSL_ERROR_BASE + 8
+  const SSL_ERROR_UNSUPPORTED_VERSION = SSL_ERROR_BASE + 9
+  const SSL_ERROR_BAD_CERT_DOMAIN = SSL_ERROR_BASE + 12
+
+  const BUFFER_SIZE = 65536
+
+  // Port of: https://github.com/mozilla/gecko-dev/blob/f51c4fa5d92d59fcb46f314e94edbf045cb3067c/dom/network/TCPServerSocket.cpp
+  class TCPServerSocketAdapter /*::implements TCPServerSocketAPI*/ {
+    /*::
+  onconnect: ?(TCPServerSocketEventAPI) => mixed;
+  onerror: ?(ErrorEventAPI) => mixed;
+  localPort: number;
+  serverSocket: ?nsIServerSocket;
+  */
+    constructor(port, options, backlog) {
+      const serverSocket = Cc[
+        "@mozilla.org/network/server-socket;1"
+      ].createInstance(Ci.nsIServerSocket)
+      serverSocket.init(port, false, backlog || -1)
+      this.serverSocket = serverSocket
+      this.localPort = serverSocket.port
+
+      serverSocket.asyncListen(this)
+    }
+    close() {
+      debug && console.log("TPCServerSocketAdapter.close", this.serverSocket)
+      if (this.serverSocket) {
+        this.serverSocket.close()
+      }
+    }
+
+    // nsIServerSocketListener
+    onSocketAccepted(server, transport) {
+      const socket = TCPSocketAdapter.createAcceptedSocket(transport)
+      TCPServerSocketAdapter.fireEvent(this, "connect", socket)
+    }
+    onStopListening(server, status) {
+      this.serverSocket = null
+      switch (status) {
+        case Cr.NS_BINDING_ABORTED: {
+          break
+        }
+        default: {
+          TCPServerSocketAdapter.fireErrorEvent(
+            this,
+            "NetworkError",
+            "Server socket was closed by unexpected reason."
+          )
+        }
+      }
+    }
+
+    // Statics
+    static fireEvent(self, type, socket /*:TCPSocketAPI*/) {
+      switch (type) {
+        case "connect": {
+          if (self.onconnect) {
+            self.onconnect({
+              type: "connect",
+              socket
+            })
+          }
+          break
+        }
+      }
+    }
+    static fireErrorEvent(self, name, message) {
+      if (self.onerror) {
+        self.onerror({
+          type: "error",
+          name,
+          message
+        })
+      }
+    }
+  }
+
+  // Port of: https://github.com/mozilla/gecko-dev/blob/f51c4fa5d92d59fcb46f314e94edbf045cb3067c/dom/network/TCPSocket.cpp#L411
+  const DO_NOT_INIT = {}
+  const ASYNC_COPY = { type: "asyncCopy" }
+  const ASYNC_READ = { type: "asyncRead" }
+
+  class TCPSocketAdapter /*::implements TCPSocketAPI*/ {
+    /*::
+    host:string;
+    port:number;
+    binaryType: TCPSocketBinaryType;
+    bufferedAmount:number;
+    transport:nsISocketTransport;
+    readyState:TCPReadyState;
+    ssl:boolean;
+    socketInputStream:?nsIInputStream
+    socketOutputStream:?nsIOutputStream
+    binaryInputStream:nsIBinaryInputStream
+    inputStreamPump:?nsIInputStreamPump
+    suspendCount:number
+    asyncCopierActive:boolean
+    waitingForDrain:boolean
+    waitingForStartTLS:boolean
+    pendingData:nsIInputStream[]
+    pendingDataAfterStartTLS:nsIInputStream[]
+    copyObserver:nsIRequestObserver
+
+    onopen:?({type:"open"}) => mixed
+    onclose:?({type:"close"}) => mixed
+    ondrain:?({type:"drain"}) => mixed
+    ondata:?({type:"data", data:ArrayBuffer}) => mixed
+    onerror:?(ErrorEventAPI) => mixed
+    */
+    constructor(
+      host /*:string*/,
+      port /*:number*/,
+      options /*::?:SocketOptions*/
+    ) {
+      this.host = host
+      this.port = port
+      this.ssl = options && options.useSecureTransport ? true : false
+      this.readyState = "closed"
+      this.asyncCopierActive = false
+      this.waitingForDrain = false
+      this.bufferedAmount = 0
+      this.suspendCount = 0
+      this.waitingForStartTLS = false
+      this.pendingData = []
+      this.pendingDataAfterStartTLS = []
+      this.binaryType = "arraybuffer"
+      this.copyObserver = new CopierObserver(this)
+
+      if (options !== DO_NOT_INIT) {
+        TCPSocketAdapter.init(this)
+      }
+    }
+    static createAcceptedSocket(transport /*:nsISocketTransport*/) {
+      const self = new TCPSocketAdapter(
+        transport.host,
+        transport.port,
+        DO_NOT_INIT
+      )
+      self.transport = transport
+
+      TCPSocketAdapter.createStream(self)
+      TCPSocketAdapter.createInputStreamPump(self)
+      self.readyState = "open"
+
+      return self
+    }
+    static init(self) {
+      self.readyState = "connecting"
+      const transportService = Cc[
+        "@mozilla.org/network/socket-transport-service;1"
+      ].getService(Ci.nsISocketTransportService)
+      const socketTypes = self.ssl ? ["ssl"] : ["starttls"]
+      const transport = transportService.createTransport(
+        socketTypes,
+        1,
+        self.host,
+        self.port,
+        null
+      )
+      TCPSocketAdapter.initWithUnconnectedTransport(self, transport)
+    }
+    static initWithUnconnectedTransport(self, transport) {
+      self.readyState = "connecting"
+      self.transport = transport
+      transport.setEventSink(self, null)
+      TCPSocketAdapter.createStream(self)
+    }
+    static createStream(self) {
+      const { transport } = self
+      const socketInputStream = transport.openInputStream(0, 0, 0)
+      const socketOutputStream = transport.openOutputStream(
+        Ci.nsITransport.OPEN_UNBUFFERED,
+        0,
+        0
+      )
+      const asyncStream = socketInputStream.QueryInterface(
+        Ci.nsIAsyncInputStream
+      )
+
+      asyncStream.asyncWait(
+        self,
+        Ci.nsIAsyncInputStream.WAIT_CLOSURE_ONLY,
+        0,
+        null
+      )
+      const binaryInputStream = Cc[
+        "@mozilla.org/binaryinputstream;1"
+      ].createInstance(Ci.nsIBinaryInputStream)
+      binaryInputStream.setInputStream(socketInputStream)
+
+      self.binaryInputStream = binaryInputStream
+      self.socketInputStream = socketInputStream
+      self.socketOutputStream = socketOutputStream
+    }
+    static createInputStreamPump(self) {
+      const { socketInputStream } = self
+      if (!socketInputStream) {
+        return IOError.throw(Cr.NS_ERROR_NOT_AVAILABLE)
+      }
+      const inputStreamPump = Cc[
+        "@mozilla.org/network/input-stream-pump;1"
+      ].createInstance(Ci.nsIInputStreamPump)
+      inputStreamPump.init(socketInputStream, 0, 0, false, null)
+
+      while (self.suspendCount--) {
+        inputStreamPump.suspend()
+      }
+      inputStreamPump.asyncRead(self, null)
+    }
+    static maybeReportErrorAndCloseIfOpen(self, status) {
+      if (self.readyState === "closed") {
+        return undefined
+      }
+      self.close()
+      self.readyState = "closed"
+
+      if (status !== Cr.NS_OK) {
+        let errorType = "SecurityProtocol"
+        let errorName = "SecurityError"
+
+        // security module? (and this is an error)
+        if ((status & 0xff0000) === 0x5a0000) {
+          const errorService = Cc[
+            "@mozilla.org/nss_errors_service;1"
+          ].getService(Ci.nsINSSErrorsService)
+          try {
+            // getErrorClass will throw a generic NS_ERROR_FAILURE if the error code is
+            // somehow not in the set of covered errors.
+            const errorClass = errorService.getErrorClass(status)
+            switch (errorClass) {
+              case Ci.nsINSSErrorsService.ERROR_CLASS_BAD_CERT: {
+                errorType = "SecurityCertificate"
+                break
+              }
+              default: {
+                break
+              }
+            }
+          } catch (_) {}
+
+          // NSS_SEC errors (happen below the base value because of negative vals)
+          if (
+            (status & 0xffff) <
+            Math.abs(Ci.nsINSSErrorsService.NSS_SEC_ERROR_BASE)
+          ) {
+            switch (status) {
+              case SEC_ERROR_EXPIRED_CERTIFICATE:
+                errorName = "SecurityExpiredCertificateError"
+                break
+              case SEC_ERROR_REVOKED_CERTIFICATE:
+                errorName = "SecurityRevokedCertificateError"
+                break
+              case SEC_ERROR_UNKNOWN_ISSUER:
+              case SEC_ERROR_UNTRUSTED_ISSUER:
+              case SEC_ERROR_UNTRUSTED_CERT:
+              case SEC_ERROR_CA_CERT_INVALID:
+                errorName = "SecurityUntrustedCertificateIssuerError"
+                break
+              case SEC_ERROR_INADEQUATE_KEY_USAGE:
+                errorName = "SecurityInadequateKeyUsageError"
+                break
+              case SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED:
+                errorName = "SecurityCertificateSignatureAlgorithmDisabledError"
+                break
+              default:
+                break
+            }
+          } else {
+            switch (status) {
+              case SSL_ERROR_NO_CERTIFICATE:
+                errorName = "SecurityNoCertificateError"
+                break
+              case SSL_ERROR_BAD_CERTIFICATE:
+                errorName = "SecurityBadCertificateError"
+                break
+              case SSL_ERROR_UNSUPPORTED_CERTIFICATE_TYPE:
+                errorName = "SecurityUnsupportedCertificateTypeError"
+                break
+              case SSL_ERROR_UNSUPPORTED_VERSION:
+                errorName = "SecurityUnsupportedTLSVersionError"
+                break
+              case SSL_ERROR_BAD_CERT_DOMAIN:
+                errorName = "SecurityCertificateDomainMismatchError"
+                break
+              default:
+                break
+            }
+          }
+        } else {
+          errorType = "Network"
+          switch (status) {
+            case Cr.NS_ERROR_CONNECTION_REFUSED: {
+              errorName = "ConnectionRefusedError"
+              break
+            }
+            case Cr.NS_ERROR_NET_TIMEOUT: {
+              errorName = "NetworkTimeoutError"
+              break
+            }
+            case Cr.NS_ERROR_UNKNOWN_HOST: {
+              errorName = "DomainNotFoundError"
+              break
+            }
+            case Cr.NS_ERROR_NET_INTERRUPT: {
+              errorName = "NetworkInterruptError"
+              break
+            }
+            default: {
+              errorName = "NetworkError"
+              break
+            }
+          }
+        }
+
+        TCPSocketAdapter.fireErrorEvent(self, errorName, errorType)
+      }
+      TCPSocketAdapter.fireEvent(self, "close")
+    }
+    static fireErrorEvent(self, name, type) {
+      const { onerror } = self
+      if (onerror) {
+        onerror({ type: "error", name, message: type })
+      }
+    }
+    static fireEvent(self, type) {
+      const event = { type }
+      switch (type) {
+        case "close": {
+          const handler = self.onclose
+          if (handler) {
+            handler({ type: "close" })
+          }
+          break
+        }
+        case "open": {
+          const handler = self.onopen
+          if (handler) {
+            handler({ type: "open" })
+          }
+          break
+        }
+        case "drain": {
+          const handler = self.ondrain
+          if (handler) {
+            handler({ type: "drain" })
+          }
+          break
+        }
+      }
+    }
+    static fireDataEvent(self, buffer) {
+      const { ondata } = self
+      if (ondata) {
+        ondata({ type: "data", data: buffer })
+      }
+    }
+    static close(self, waitForUnsentData /*:boolean*/) {
+      if (self.readyState === "closed" || self.readyState === "closing") {
+        return undefined
+      }
+      self.readyState = "closing"
+      if (self.asyncCopierActive || !waitForUnsentData) {
+        self.pendingData.splice(0)
+        self.pendingDataAfterStartTLS.splice(0)
+
+        const { socketOutputStream, socketInputStream } = self
+        if (socketOutputStream) {
+          socketOutputStream.close()
+          self.socketOutputStream = null
+          delete self.binaryInputStream
+        }
+
+        if (socketInputStream) {
+          socketInputStream.close()
+          self.socketInputStream = null
+        }
+      }
+    }
+    static send(self, stream, byteLength) {
+      debug && console.log(`TCPSocketAdapter.send ${stream.available()}`)
+      self.bufferedAmount += byteLength
+      const isBufferFull = self.bufferedAmount > BUFFER_SIZE
+      if (isBufferFull) {
+        self.waitingForDrain = true
+      }
+
+      if (self.waitingForStartTLS) {
+        self.pendingDataAfterStartTLS.push(stream)
+      } else {
+        self.pendingData.push(stream)
+      }
+      TCPSocketAdapter.ensureCopying(self)
+
+      return !isBufferFull
+    }
+    static ensureCopying(self) {
+      const { socketOutputStream, asyncCopierActive } = self
+
+      if (asyncCopierActive || !socketOutputStream) {
+        return
+      }
+      self.asyncCopierActive = true
+      const multiplexStream = Cc[
+        "@mozilla.org/io/multiplex-input-stream;1"
+      ].createInstance(Ci.nsIMultiplexInputStream)
+
+      const multiplex$inputStream /*:nsISupports<nsIInputStream>*/ = multiplexStream
+      const stream = multiplex$inputStream.QueryInterface(Ci.nsIInputStream)
+
+      while (self.pendingData.length > 0) {
+        const stream = self.pendingData.shift()
+        multiplexStream.appendStream(stream)
+      }
+
+      const copier = Cc[
+        "@mozilla.org/network/async-stream-copier;1"
+      ].createInstance(Ci.nsIAsyncStreamCopier)
+      const socketTransportService = Cc[
+        "@mozilla.org/network/socket-transport-service;1"
+      ].getService(Ci.nsISocketTransportService)
+
+      const $target /*:nsISupports<nsIEventTarget>*/ = socketTransportService
+      const target = $target.QueryInterface(Ci.nsIEventTarget)
+
+      debug &&
+        console.log(
+          `TCPSocketAdapter.ensureCopying copy ${stream.available()} bytes`
+        )
+
+      copier.init(
+        stream,
+        socketOutputStream,
+        target,
+        true,
+        false,
+        BUFFER_SIZE,
+        false,
+        false
+      )
+
+      copier.asyncCopy(self.copyObserver, null)
+    }
+    static notifyCopyComplete(self, status) {
+      debug && console.log(`TCPSocketAdapter.notifyCopyComplete ${status}`)
+      self.asyncCopierActive = false
+      let bufferedAmount = 0
+      for (const stream of self.pendingData) {
+        bufferedAmount += stream.available()
+      }
+      self.bufferedAmount = bufferedAmount
+
+      if (status !== Cr.NS_OK) {
+        return TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(self, status)
+      }
+
+      if (bufferedAmount > 0) {
+        return TCPSocketAdapter.ensureCopying(self)
+      }
+
+      // Maybe we have some empty stream. We want to have an empty queue now.
+      self.pendingData.splice(0)
+      // If we are waiting for initiating starttls, we can begin to
+      // activate tls now.
+      if (self.waitingForStartTLS && self.readyState === "open") {
+        TCPSocketAdapter.activateTLS(self)
+        self.waitingForStartTLS = false
+        // If we have pending data, we should send them, or fire
+        // a drain event if we are waiting for it.
+        if (self.pendingDataAfterStartTLS.length !== 0) {
+          self.pendingData = self.pendingDataAfterStartTLS
+          return TCPSocketAdapter.ensureCopying(self)
+        }
+      }
+
+      if (self.waitingForDrain) {
+        self.waitingForDrain = false
+        TCPSocketAdapter.fireEvent(self, "drain")
+      }
+
+      if (self.readyState === "closing") {
+        const { socketOutputStream } = self
+        if (socketOutputStream) {
+          socketOutputStream.close()
+          self.socketOutputStream = null
+        }
+        self.readyState = "closed"
+        delete self.copyObserver
+        TCPSocketAdapter.fireEvent(self, "close")
+      }
+    }
+    static activateTLS(self) {
+      const { securityInfo } = self.transport
+      const socketControl = securityInfo.QueryInterface(Ci.nsISSLSocketControl)
+      if (socketControl) {
+        socketControl.StartTLS()
+        self.ssl = true
+      }
+    }
+
+    onTransportStatus(transport, status, progress, max) {
+      this.readyState = "open"
+      TCPSocketAdapter.createInputStreamPump(self)
+      TCPSocketAdapter.fireEvent(self, "open")
+    }
+    onStartRequest(request, context) {}
+    onDataAvailable(request, stream /*:nsIInputStream*/, offset, size) {
+      const buffer = new ArrayBuffer(size)
+      this.binaryInputStream.readArrayBuffer(size, buffer)
+      TCPSocketAdapter.fireDataEvent(this, buffer)
+    }
+    onStopRequest(request, status) {
+      debug && console.log(`TCPSocketAdapter.notifyReadComplete ${status}`)
+      this.inputStreamPump = null
+      if (this.asyncCopierActive && status === Cr.NS_OK) {
+        // If we have some buffered output still, and status is not an
+        // error, the other side has done a half-close, but we don't
+        // want to be in the close state until we are done sending
+        // everything that was buffered. We also don't want to call onclose
+        // yet.
+        return undefined
+      } else {
+        return TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(this, status)
+      }
+    }
+    onInputStreamReady(asyncStream /*:nsIAsyncInputStream*/) /*:void*/ {
+      // Only used for detecting if the connection was refused.
+      try {
+        const available = asyncStream.available()
+        debug &&
+          console.log(
+            `TCPSocketAdapter.onInputStreamReady available: ${available}`
+          )
+      } catch (error) {
+        debug &&
+          console.log(
+            `TCPSocketAdapter.onInputStreamReady unavailable: ${error}`
+          )
+        TCPSocketAdapter.maybeReportErrorAndCloseIfOpen(this, error)
+      }
+    }
+
+    send(
+      buffer /*:ArrayBuffer*/,
+      byteOffset /*:number*/ = 0,
+      byteLength = buffer.byteLength
+    ) {
+      if (this.readyState !== "open") {
+        return IOError.throw("Socket is not open")
+      }
+      const stream = Cc[
+        "@mozilla.org/io/arraybuffer-input-stream;1"
+      ].createInstance(Ci.nsIArrayBufferInputStream)
+      stream.setData(buffer, byteOffset, byteLength)
+      return TCPSocketAdapter.send(this, stream, byteLength)
+    }
+    suspend() {}
+    resume() {}
+    close() {
+      TCPSocketAdapter.close(this, true)
+    }
+    closeImmediately() {
+      TCPSocketAdapter.close(this, false)
+    }
+    upgradeToSecure() {
+      if (this.readyState !== "open") {
+        return IOError.throw(Cr.NS_ERROR_FAILURE)
+      }
+      if (!this.ssl) {
+        return
+      }
+      if (!this.asyncCopierActive) {
+        TCPSocketAdapter.activateTLS(this)
+      } else {
+        this.waitingForStartTLS = true
+      }
+    }
+  }
+
+  class CopierObserver {
+    /*::
+    owner:TCPSocketAdapter
+    */
+    constructor(socket) {
+      this.owner = socket
+    }
+    onStartRequest(request) {}
+    onStopRequest(request, status) {
+      TCPSocketAdapter.notifyCopyComplete(this.owner, status)
+    }
+  }
+
+  const debug = env.get("MOZ_ENV") === "DEBUG"
+}

--- a/src/toolkit/components/extensions/parent/ext-tcp.js
+++ b/src/toolkit/components/extensions/parent/ext-tcp.js
@@ -244,8 +244,7 @@ Cu.importGlobalProperties(["URL"])
                 }
                 socket.onclose = () => {
                   emit(["close", serialiseSocket(socket, client.id)])
-                  // cleanup the socket after 1s
-                  setTimeout(() => clients.delete(client.id), 1000)
+                  clients.delete(client.id)
                 }
                 socket.ondata = event => {
                   emit(["data", serialiseSocket(socket, client.id), event.data])

--- a/src/toolkit/components/extensions/parent/ext-udp.js
+++ b/src/toolkit/components/extensions/parent/ext-udp.js
@@ -1,0 +1,274 @@
+// @flow strict
+
+/*::
+import { Cu, Cr, Ci, Cc, ExtensionAPI } from "gecko"
+
+import type {BaseContext, nsIUDPSocket, nsIUDPSocketListener, nsINetAddr} from "gecko"
+import type {
+  UDPSocket,
+  UDPSocketManager,
+  UDPMessage,
+  SocketAddress,
+  SocketOptions,
+  Family
+} from "../interface/udp"
+
+interface Host {
+  +UDPSocket: UDPSocketManager;
+}
+*/
+Cu.importGlobalProperties(["URL"])
+
+{
+  global.UDPSocket = class extends ExtensionAPI /*::<Host>*/ {
+    getAPI(context) {
+      const sockets = new Map()
+      const messages = new Map()
+      const notFoundPromise = "not found"
+
+      class MessagesHost {
+        /*::
+        socket:nsIUDPSocket
+        requests:{resolve({done:false, value:UDPMessage}|{done:true}):void, reject(Error):void}[]
+        responses:Promise<{done:false, value:UDPMessage}>[]
+        isDone:boolean
+        done:Promise<{done:true, value:void}>
+        scope:Object
+        */
+        constructor(socket) {
+          this.socket = socket
+          this.isDone = false
+          this.requests = []
+          this.responses = []
+          this.scope = context.cloneScope
+        }
+        onPacketReceived(socket, message) {
+          const { scope } = this
+          debug && console.log(`TCPSocket/onPacketReceived`, message)
+          const { address, port, family } = message.fromAddr
+          this.continue(
+            Cu.cloneInto(
+              [
+                message.rawData.buffer,
+                Cu.cloneInto({ address, port, family }, scope)
+              ],
+              scope
+            )
+          )
+        }
+        onStopListening(socket, status) {
+          debug && console.log(`TCPSocket/onStopListening`, status)
+
+          if (status === Cr.NS_BINDING_ABORTED) {
+            return this.break()
+          } else {
+            return this.throw(
+              new Error(`Socket was closed with error: ${status}`)
+            )
+          }
+        }
+        continue(value) {
+          const { requests, isDone, responses, scope } = this
+          if (isDone) {
+            throw Error("Received message after iteration was done")
+          } else {
+            debug && console.log("UDPSocket.MessagesHost.continue", value)
+            const nextIteration = { done: false, value }
+            const request = requests.shift()
+            if (request) {
+              request.resolve(nextIteration)
+            } else {
+              responses.push(scope.Promise.resolve(nextIteration))
+            }
+          }
+        }
+        break() {
+          const { requests } = this
+          for (const request of requests) {
+            request.resolve({ done: true })
+          }
+        }
+        throw(error) {
+          const { requests } = this
+          for (const request of requests) {
+            request.reject(error)
+          }
+        }
+        next() {
+          const { responses, requests, done, isDone } = this
+          const response = responses.shift()
+          if (response) {
+            return response
+          } else if (isDone) {
+            return done
+          } else {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              requests.push({ resolve, reject })
+            })
+          }
+        }
+        return() {
+          const { isDone, done } = this
+          if (!isDone) {
+            this.isDone = true
+            this.socket.close()
+          }
+          return { done: true }
+        }
+      }
+
+      context.callOnClose({
+        close() {
+          for (const socket of sockets.values()) {
+            socket.close()
+          }
+          sockets.clear()
+        }
+      })
+      let socketIdx = 0
+
+      return {
+        UDPSocket: {
+          create: options => {
+            return new Promise((resolve, reject) => {
+              try {
+                const socket = Cc[
+                  "@mozilla.org/network/udp-socket;1"
+                ].createInstance(Ci.nsIUDPSocket)
+
+                if (options.host != null) {
+                  socket.init2(
+                    options.host,
+                    options.port || -1,
+                    null,
+                    options.addressReuse != false
+                  )
+                } else {
+                  socket.init(
+                    options.port || -1,
+                    options.loopbackOnly != false,
+                    null,
+                    options.addressReuse != false
+                  )
+                }
+
+                const { address, port, family } = socket.localAddr
+                const id = ++socketIdx
+                sockets.set(id, socket)
+
+                resolve({
+                  id,
+                  address,
+                  port,
+                  family
+                })
+              } catch (error) {
+                reject(error.message)
+              }
+            })
+          },
+          close: socketId => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                socket.close()
+                sockets.delete(socketId)
+                resolve()
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          send: (socketId, host, port, data, size) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                const n = socket.send(
+                  host,
+                  port,
+                  new Uint8Array(data),
+                  size || data.byteLength
+                )
+                resolve(n)
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          setMulticastLoopback: (socketId, flag) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                socket.multicastLoopback = flag
+                resolve()
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          setMulticastInterface: (socketId, multicastInterface) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                socket.multicastInterface = multicastInterface
+                resolve()
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          joinMulticast: (socketId, address, multicastInterface) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                socket.joinMulticast(address, multicastInterface)
+                resolve()
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          leaveMulticast: (socketId, address, multicastInterface) => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (sockets.has(socketId)) {
+                const socket = sockets.get(socketId)
+                socket.leaveMulticast(address, multicastInterface)
+                resolve()
+              } else {
+                reject(notFoundPromise)
+              }
+            })
+          },
+          pollMessages: socketId => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (!sockets.has(socketId)) {
+                return reject(notFoundPromise)
+              }
+              let host
+              if (!messages.has(socketId)) {
+                const socket = sockets.get(socketId)
+                host = new MessagesHost(socket)
+                socket.asyncListen(host)
+                messages.set(socketId, host)
+              } else {
+                host = messages.get(socketId)
+              }
+              resolve(host.next())
+            })
+          },
+          returnHost: socketId => {
+            return new context.cloneScope.Promise((resolve, reject) => {
+              if (!sockets.has(socketId) || !messages.has(socketId)) {
+                return reject(notFoundPromise)
+              }
+              const result = messages.get(socketId).return()
+              resolve(result)
+            })
+          }
+        }
+      }
+    }
+  }
+
+  const debug = false
+}

--- a/src/toolkit/components/extensions/parent/ext-udp.js
+++ b/src/toolkit/components/extensions/parent/ext-udp.js
@@ -44,7 +44,7 @@ Cu.importGlobalProperties(["URL"])
         }
         onPacketReceived(socket, message) {
           const { scope } = this
-          debug && console.log(`TCPSocket/onPacketReceived`, message)
+          debug && console.log(`UDPSocket/onPacketReceived`, message)
           const { address, port, family } = message.fromAddr
           this.continue(
             Cu.cloneInto(
@@ -57,7 +57,7 @@ Cu.importGlobalProperties(["URL"])
           )
         }
         onStopListening(socket, status) {
-          debug && console.log(`TCPSocket/onStopListening`, status)
+          debug && console.log(`UDPSocket/onStopListening`, status)
 
           if (status === Cr.NS_BINDING_ABORTED) {
             return this.break()
@@ -155,6 +155,7 @@ Cu.importGlobalProperties(["URL"])
                 const { address, port, family } = socket.localAddr
                 const id = ++socketIdx
                 sockets.set(id, socket)
+                debug && console.log(`UDPSocket/create`, socket.localAddr)
 
                 resolve({
                   id,
@@ -171,6 +172,7 @@ Cu.importGlobalProperties(["URL"])
             return new context.cloneScope.Promise((resolve, reject) => {
               if (sockets.has(socketId)) {
                 const socket = sockets.get(socketId)
+                debug && console.log(`UDPSocket/close`, socket.localAddr)
                 socket.close()
                 sockets.delete(socketId)
                 resolve()
@@ -183,6 +185,7 @@ Cu.importGlobalProperties(["URL"])
             return new context.cloneScope.Promise((resolve, reject) => {
               if (sockets.has(socketId)) {
                 const socket = sockets.get(socketId)
+                debug && console.log(`UDPSocket/send`, socket.localAddr, data)
                 const n = socket.send(
                   host,
                   port,

--- a/src/toolkit/components/extensions/parent/ext-udp.js
+++ b/src/toolkit/components/extensions/parent/ext-udp.js
@@ -14,7 +14,7 @@ import type {
 } from "../interface/udp"
 
 interface Host {
-  +UDPSocket: UDPSocketManager;
+  +UDPSocket: {};
 }
 */
 Cu.importGlobalProperties(["URL"])
@@ -129,7 +129,7 @@ Cu.importGlobalProperties(["URL"])
 
       return {
         UDPSocket: {
-          create: options => {
+          createSocket: options => {
             return new Promise((resolve, reject) => {
               try {
                 const socket = Cc[
@@ -170,8 +170,8 @@ Cu.importGlobalProperties(["URL"])
           },
           close: socketId => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 debug && console.log(`UDPSocket/close`, socket.localAddr)
                 socket.close()
                 sockets.delete(socketId)
@@ -183,8 +183,8 @@ Cu.importGlobalProperties(["URL"])
           },
           send: (socketId, host, port, data, size) => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 debug && console.log(`UDPSocket/send`, socket.localAddr, data)
                 const n = socket.send(
                   host,
@@ -200,8 +200,8 @@ Cu.importGlobalProperties(["URL"])
           },
           setMulticastLoopback: (socketId, flag) => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 socket.multicastLoopback = flag
                 resolve()
               } else {
@@ -211,8 +211,8 @@ Cu.importGlobalProperties(["URL"])
           },
           setMulticastInterface: (socketId, multicastInterface) => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 socket.multicastInterface = multicastInterface
                 resolve()
               } else {
@@ -222,8 +222,8 @@ Cu.importGlobalProperties(["URL"])
           },
           joinMulticast: (socketId, address, multicastInterface) => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 socket.joinMulticast(address, multicastInterface)
                 resolve()
               } else {
@@ -233,8 +233,8 @@ Cu.importGlobalProperties(["URL"])
           },
           leaveMulticast: (socketId, address, multicastInterface) => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (sockets.has(socketId)) {
-                const socket = sockets.get(socketId)
+              const socket = sockets.get(socketId)
+              if (socket) {
                 socket.leaveMulticast(address, multicastInterface)
                 resolve()
               } else {
@@ -244,27 +244,26 @@ Cu.importGlobalProperties(["URL"])
           },
           pollMessages: socketId => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (!sockets.has(socketId)) {
+              const socket = sockets.get(socketId)
+              if (!socket) {
                 return reject(notFoundPromise)
               }
-              let host
-              if (!messages.has(socketId)) {
-                const socket = sockets.get(socketId)
+              let host = messages.get(socketId)
+              if (!host) {
                 host = new MessagesHost(socket)
                 socket.asyncListen(host)
                 messages.set(socketId, host)
-              } else {
-                host = messages.get(socketId)
               }
               resolve(host.next())
             })
           },
           returnHost: socketId => {
             return new context.cloneScope.Promise((resolve, reject) => {
-              if (!sockets.has(socketId) || !messages.has(socketId)) {
+              const message = messages.get(socketId)
+              if (!sockets.has(socketId) || !message) {
                 return reject(notFoundPromise)
               }
-              const result = messages.get(socketId).return()
+              const result = message.return()
               resolve(result)
             })
           }

--- a/src/toolkit/components/extensions/schemas/tcp.json
+++ b/src/toolkit/components/extensions/schemas/tcp.json
@@ -3,7 +3,19 @@
     "namespace": "TCPSocket",
     "description": "TCP Client Socket implementation",
     "//permissions": ["TCPClientSocket", "TCPServerSocket"],
-    "types": [],
+    "types": [
+      {
+        "id": "TCPClient",
+        "type": "object",
+        "description": "TCP Client",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "host"
+          }
+        }
+      }
+    ],
     "properties": {},
     "events": [],
     "functions": [

--- a/src/toolkit/components/extensions/test/tcp/manifest.json
+++ b/src/toolkit/components/extensions/test/tcp/manifest.json
@@ -16,6 +16,11 @@
     },
     "TCPSocket": {
       "schema": "../../schemas/tcp.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["TCPSocket"]],
+        "script": "../../parent/ext-tcp.js"
+      },
       "child": {
         "scopes": ["addon_child"],
         "paths": [["TCPSocket"]],

--- a/src/toolkit/components/extensions/test/udp/manifest.json
+++ b/src/toolkit/components/extensions/test/udp/manifest.json
@@ -16,6 +16,11 @@
     },
     "UDPSocket": {
       "schema": "../../schemas/udp.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["UDPSocket"]],
+        "script": "../../parent/ext-udp.js"
+      },
       "child": {
         "scopes": ["addon_child"],
         "paths": [["UDPSocket"]],


### PR DESCRIPTION
The current `TCPSocket` and `UDPSocket` implements run in the extension child process. This is fine for debugging, but we found that when running in a release browser with the process sandbox enabled then this process was blocked from opening sockets on Mac and Linux, meaning the APIs did not work.

This PR fixes this issue by implementing both `TCPSocket` and `UDPSocket` APIs in the parent process. The API exposed by the child to the extension has not changed, but now everything is shipped up to the parent, which then pushes data back to the child.

 * Whether this introduces an additional performance cost, I do not know. I didn't do any performance benchmarks, but also didn't see much change in the dat-webext extension after adopting these changes.
 * The original test suite is passing as-is, but there may be untested regressions I have overlooked. I'm not 100% that the error handling behaves as before.
 * I omitted flow types for the internal parent-process APIs. If you think they're useful I could add that. The flow check is passing at the moment.